### PR TITLE
 Refactor 7# Transfer authentication to Controller layer

### DIFF
--- a/src/main/java/com/example/maghouse/auth/controller/BaseController.java
+++ b/src/main/java/com/example/maghouse/auth/controller/BaseController.java
@@ -1,0 +1,28 @@
+package com.example.maghouse.auth.controller;
+
+import com.example.maghouse.auth.registration.user.User;
+import com.example.maghouse.auth.registration.user.UserService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@Slf4j
+public abstract class BaseController {
+
+    protected final UserService userService;
+
+    protected BaseController(UserService userService) {
+        this.userService = userService;
+    }
+
+    protected User getAuthenticateUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            log.warn("Authentication failed - user not authenticated!");
+            throw new SecurityException("Authentication failed - user not authenticated!");
+        }
+        String email = authentication.getName();
+        log.debug("User authenticated: {}", email);
+        return userService.findByEmail(email);
+    }
+}

--- a/src/main/java/com/example/maghouse/auth/controller/BaseController.java
+++ b/src/main/java/com/example/maghouse/auth/controller/BaseController.java
@@ -15,7 +15,7 @@ public abstract class BaseController {
         this.userService = userService;
     }
 
-    protected User getAuthenticateUser() {
+    protected User getAuthenticatedUser() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null || !authentication.isAuthenticated()) {
             log.warn("Authentication failed - user not authenticated!");

--- a/src/main/java/com/example/maghouse/auth/controller/DeliveryController.java
+++ b/src/main/java/com/example/maghouse/auth/controller/DeliveryController.java
@@ -1,7 +1,6 @@
 package com.example.maghouse.auth.controller;
 
 import com.example.maghouse.auth.registration.user.User;
-import com.example.maghouse.auth.registration.user.UserService;
 import com.example.maghouse.delivery.DeliveryEntity;
 import com.example.maghouse.delivery.DeliveryRequest;
 import com.example.maghouse.delivery.DeliveryResponse;
@@ -9,6 +8,7 @@ import com.example.maghouse.delivery.DeliveryService;
 import com.example.maghouse.delivery.status.DeliveryStatus;
 import com.example.maghouse.delivery.status.DeliveryStatusRequest;
 import com.example.maghouse.mapper.DeliveryResponseToDeliveryMapper;
+import com.example.maghouse.security.AuthenticationHelper;
 import com.example.maghouse.warehouse.location.WarehouseLocation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -17,8 +17,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -30,18 +32,12 @@ import java.util.stream.Collectors;
 @RequestMapping(path = "/deliveries/")
 @Tag(name = "Delivery Management", description = "Endpoints for creating and updating delivery status.")
 @SecurityRequirement(name = "bearerAuth")
-public class DeliveryController extends BaseController {
+@RequiredArgsConstructor
+public class DeliveryController  {
 
     private final DeliveryService deliveryService;
     private final DeliveryResponseToDeliveryMapper deliveryResponseToDeliveryMapper;
-
-    public DeliveryController(UserService userService,
-                              DeliveryService deliveryService,
-                              DeliveryResponseToDeliveryMapper deliveryResponseToDeliveryMapper) {
-        super(userService);
-        this.deliveryService = deliveryService;
-        this.deliveryResponseToDeliveryMapper = deliveryResponseToDeliveryMapper;
-    }
+    private final AuthenticationHelper authenticationHelper;
 
     @GetMapping
     @Operation(summary = "Get all deliveries", description = "Retrieves a list of all deliveries.")
@@ -49,8 +45,8 @@ public class DeliveryController extends BaseController {
             @ApiResponse(responseCode = "200", description = "Successfully retrieved list of deliveries"),
             @ApiResponse(responseCode = "401", description = "Unauthorized access")
     })
-    public ResponseEntity<List<DeliveryResponse>> getAllDeliveries() {
-        User user = getAuthenticatedUser();
+    public ResponseEntity<List<DeliveryResponse>> getAllDeliveries(Authentication authentication) {
+        User user = authenticationHelper.getAuthenticatedUser(authentication);
         List<DeliveryEntity> deliveries = deliveryService.getAllDeliveries();
         List<DeliveryResponse> responses = deliveries.stream()
                 .map(deliveryResponseToDeliveryMapper::mapToResponse)
@@ -65,8 +61,9 @@ public class DeliveryController extends BaseController {
             @ApiResponse(responseCode = "404", description = "No deliveries found for the given status"),
             @ApiResponse(responseCode = "401", description = "Unauthorized access")
     })
-    public ResponseEntity<List<DeliveryResponse>> getDeliveriesByStatus(@PathVariable DeliveryStatus status) {
-        User user = getAuthenticatedUser();
+    public ResponseEntity<List<DeliveryResponse>> getDeliveriesByStatus(@PathVariable DeliveryStatus status,
+                                                                        Authentication authentication) {
+        User user = authenticationHelper.getAuthenticatedUser(authentication);
         List<DeliveryEntity> deliveries = deliveryService.getDeliveriesByStatus(status);
         if (deliveries.isEmpty()) {
             return ResponseEntity.notFound().build();
@@ -84,8 +81,9 @@ public class DeliveryController extends BaseController {
             @ApiResponse(responseCode = "404", description = "Delivery with the given number not found"),
             @ApiResponse(responseCode = "401", description = "Unauthorized access")
     })
-    public ResponseEntity<DeliveryResponse> getDeliveryByNumber(@PathVariable String deliveryNumber) {
-        User user = getAuthenticatedUser();
+    public ResponseEntity<DeliveryResponse> getDeliveryByNumber(@PathVariable String deliveryNumber,
+                                                                Authentication authentication) {
+        User user = authenticationHelper.getAuthenticatedUser(authentication);
         Optional<DeliveryEntity> delivery = deliveryService.getDeliveryByNumber(deliveryNumber);
         if (delivery.isEmpty()) {
             return ResponseEntity.notFound().build();
@@ -101,8 +99,9 @@ public class DeliveryController extends BaseController {
             @ApiResponse(responseCode = "404", description = "No deliveries found for the given supplier"),
             @ApiResponse(responseCode = "401", description = "Unauthorized access")
     })
-    public ResponseEntity<List<DeliveryResponse>> getDeliveriesBySupplier(@PathVariable String supplierName) {
-        User user = getAuthenticatedUser();
+    public ResponseEntity<List<DeliveryResponse>> getDeliveriesBySupplier(@PathVariable String supplierName,
+                                                                          Authentication authentication) {
+        User user = authenticationHelper.getAuthenticatedUser(authentication);
         List<DeliveryEntity> deliveries = deliveryService.getDeliveriesBySupplier(supplierName);
         if (deliveries.isEmpty()) {
             return ResponseEntity.notFound().build();
@@ -120,8 +119,9 @@ public class DeliveryController extends BaseController {
             @ApiResponse(responseCode = "404", description = "No deliveries found for the given location"),
             @ApiResponse(responseCode = "401", description = "Unauthorized access")
     })
-    public ResponseEntity<List<DeliveryResponse>> getDeliveriesByLocation(@PathVariable WarehouseLocation warehouseLocation) {
-        User user = getAuthenticatedUser();
+    public ResponseEntity<List<DeliveryResponse>> getDeliveriesByLocation(@PathVariable WarehouseLocation warehouseLocation,
+                                                                          Authentication authentication) {
+        User user = authenticationHelper.getAuthenticatedUser(authentication);
         List<DeliveryEntity> deliveries = deliveryService.getDeliveriesByLocation(warehouseLocation);
         if (deliveries.isEmpty()) {
             return ResponseEntity.notFound().build();
@@ -139,8 +139,9 @@ public class DeliveryController extends BaseController {
             @ApiResponse(responseCode = "404", description = "No deliveries found for the given item code"),
             @ApiResponse(responseCode = "401", description = "Unauthorized access")
     })
-    public ResponseEntity<List<DeliveryResponse>> getDeliveriesByItemCode(@PathVariable String itemCode) {
-        User user = getAuthenticatedUser();
+    public ResponseEntity<List<DeliveryResponse>> getDeliveriesByItemCode(@PathVariable String itemCode,
+                                                                          Authentication authentication) {
+        User user = authenticationHelper.getAuthenticatedUser(authentication);
         List<DeliveryEntity> deliveries = deliveryService.getDeliveriesByItemCode(itemCode);
         if (deliveries.isEmpty()) {
             return ResponseEntity.notFound().build();
@@ -158,8 +159,8 @@ public class DeliveryController extends BaseController {
             @ApiResponse(responseCode = "404", description = "Delivery with the given ID not found"),
             @ApiResponse(responseCode = "401", description = "Unauthorized access")
     })
-    public ResponseEntity<DeliveryResponse> getDeliveryById(@PathVariable Long id) {
-        User user = getAuthenticatedUser();
+    public ResponseEntity<DeliveryResponse> getDeliveryById(@PathVariable Long id, Authentication authentication) {
+        User user = authenticationHelper.getAuthenticatedUser(authentication);
         Optional<DeliveryEntity> delivery = deliveryService.getDeliveryById(id);
         if (delivery.isEmpty()) {
             return ResponseEntity.notFound().build();
@@ -179,8 +180,9 @@ public class DeliveryController extends BaseController {
             @ApiResponse(responseCode = "401", description = "Unauthorized access (missing or invalid token)",
                     content = @Content)
     })
-    public ResponseEntity<DeliveryResponse> create(@RequestBody  DeliveryRequest deliveryRequest){
-        User user = getAuthenticatedUser();
+    public ResponseEntity<DeliveryResponse> create(@RequestBody  DeliveryRequest deliveryRequest,
+                                                   Authentication authentication){
+        User user = authenticationHelper.getAuthenticatedUser(authentication);
         if (deliveryRequest == null) {
             throw new IllegalArgumentException("Delivery request cannot be null");
         }
@@ -203,8 +205,8 @@ public class DeliveryController extends BaseController {
                     content = @Content(schema = @Schema(implementation = Map.class)))
     })
     public ResponseEntity<DeliveryResponse> updateDeliveryStatus(@RequestBody DeliveryStatusRequest deliveryStatusRequest,
-                                         @PathVariable Long id){
-        User user = getAuthenticatedUser();
+                                         @PathVariable Long id, Authentication authentication){
+        User user = authenticationHelper.getAuthenticatedUser(authentication);
         if(deliveryStatusRequest == null || id == null) {
             throw new IllegalArgumentException("Delivery status request cannot be null");
         }

--- a/src/main/java/com/example/maghouse/auth/controller/WarehouseController.java
+++ b/src/main/java/com/example/maghouse/auth/controller/WarehouseController.java
@@ -1,11 +1,11 @@
 package com.example.maghouse.auth.controller;
 
 import com.example.maghouse.auth.registration.user.User;
-import com.example.maghouse.auth.registration.user.UserService;
 import com.example.maghouse.item.ItemEntity;
 import com.example.maghouse.item.ItemResponse;
 import com.example.maghouse.mapper.ItemResponseToItemMapper;
 import com.example.maghouse.mapper.WarehouseResponseToWarehouseMapper;
+import com.example.maghouse.security.AuthenticationHelper;
 import com.example.maghouse.warehouse.WarehouseEntity;
 import com.example.maghouse.warehouse.WarehouseRequest;
 import com.example.maghouse.warehouse.WarehouseResponse;
@@ -19,9 +19,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -32,22 +34,15 @@ import java.util.stream.Collectors;
 @RequestMapping(path = "/warehouses/")
 @Tag(name = "Warehouse Structure", description = "Endpoints for creating warehouses and managing item storage locations.")
 @SecurityRequirement(name = "bearerAuth")
+@RequiredArgsConstructor
 @Slf4j
-public class WarehouseController extends BaseController {
+public class WarehouseController {
 
     private final WarehouseService warehouseService;
     private final WarehouseResponseToWarehouseMapper warehouseResponseToWarehouseMapper;
     private final ItemResponseToItemMapper itemResponseToItemMapper;
+    private final AuthenticationHelper authenticationHelper;
 
-    public WarehouseController(UserService userService,
-                                  WarehouseService warehouseService,
-                                  WarehouseResponseToWarehouseMapper warehouseResponseToWarehouseMapper,
-                                  ItemResponseToItemMapper itemResponseToItemMapper) {
-        super(userService);
-        this.warehouseService = warehouseService;
-        this.warehouseResponseToWarehouseMapper = warehouseResponseToWarehouseMapper;
-        this.itemResponseToItemMapper = itemResponseToItemMapper;
-    }
 
 
     @GetMapping
@@ -59,8 +54,8 @@ public class WarehouseController extends BaseController {
             @ApiResponse(responseCode = "403", description = "Forbidden (Access denied)",
                     content = @Content)
     })
-    public ResponseEntity<List<WarehouseResponse>> getAllWarehouses() {
-        User user = getAuthenticatedUser();
+    public ResponseEntity<List<WarehouseResponse>> getAllWarehouses( Authentication authentication) {
+        User user = authenticationHelper.getAuthenticatedUser(authentication);
         log.info("User {} requested all warehouses", user.getEmail());
         List<WarehouseEntity> warehouses = warehouseService.getAllWarehouses();
         List<WarehouseResponse> responses = warehouses.stream()
@@ -82,8 +77,9 @@ public class WarehouseController extends BaseController {
                     content = @Content)
     })
     public ResponseEntity<List<ItemResponse>> getItemsByLocationPrefix(
-            @PathVariable WarehouseLocationRequest warehouseLocationRequest) {
-        User user = getAuthenticatedUser();
+            @PathVariable WarehouseLocationRequest warehouseLocationRequest,
+            Authentication authentication) {
+        User user = authenticationHelper.getAuthenticatedUser(authentication);
         log.info("User {} requested all warehouses", user.getEmail());
         List<ItemEntity> items = warehouseService.getAllItemsByLocationCodePrefix(
                 warehouseLocationRequest.getWarehouseLocation());
@@ -110,8 +106,9 @@ public class WarehouseController extends BaseController {
             @ApiResponse(responseCode = "403", description = "Forbidden (admin:create required)",
                     content = @Content)
     })
-    public ResponseEntity<WarehouseResponse> create(@RequestBody WarehouseRequest warehouseRequest) {
-        User user = getAuthenticatedUser();
+    public ResponseEntity<WarehouseResponse> create(@RequestBody WarehouseRequest warehouseRequest,
+                                                    Authentication authentication) {
+        User user = authenticationHelper.getAuthenticatedUser(authentication);
         log.info("User {} requested all warehouses", user.getEmail());
         WarehouseEntity warehouse = warehouseService.createWarehouse(warehouseRequest, user);
         WarehouseResponse warehouseResponse = warehouseResponseToWarehouseMapper.mapToWarehouse(warehouse);
@@ -133,8 +130,9 @@ public class WarehouseController extends BaseController {
                     content = @Content)
     })
     public ResponseEntity<ItemResponse> assignSpaceType(@PathVariable Long itemId,
-                                                        @RequestBody WarehouseSpaceTypeRequest warehouseSpaceTypeRequest) {
-        User user = getAuthenticatedUser();
+                                                        @RequestBody WarehouseSpaceTypeRequest warehouseSpaceTypeRequest,
+                                                        Authentication authentication) {
+        User user = authenticationHelper.getAuthenticatedUser(authentication);
         log.info("User {} requested all warehouses", user.getEmail());
         ItemEntity item = warehouseService.assignWarehouseSpaceType(warehouseSpaceTypeRequest, itemId, user);
         ItemResponse response = itemResponseToItemMapper.mapToItem(item);
@@ -154,8 +152,9 @@ public class WarehouseController extends BaseController {
                     content = @Content)
     })
     public ResponseEntity<ItemResponse> assignWarehouseLocation(@PathVariable Long itemId,
-                                                                @RequestBody WarehouseLocationRequest warehouseLocationRequest) {
-        User user = getAuthenticatedUser();
+                                                                @RequestBody WarehouseLocationRequest warehouseLocationRequest,
+                                                                Authentication authentication) {
+        User user = authenticationHelper.getAuthenticatedUser(authentication);
         log.info("User {} requested all warehouses", user.getEmail());
         ItemEntity item = warehouseService.assignItemsToWarehouseLocation(warehouseLocationRequest, itemId, user);
         ItemResponse response = itemResponseToItemMapper.mapToItem(item);
@@ -174,8 +173,9 @@ public class WarehouseController extends BaseController {
                     content = @Content)
     })
     public ResponseEntity<ItemResponse> updateWarehouseLocation(@PathVariable Long itemId,
-                                                                @RequestBody WarehouseLocationRequest warehouseLocationRequest) {
-        User user = getAuthenticatedUser();
+                                                                @RequestBody WarehouseLocationRequest warehouseLocationRequest,
+                                                                Authentication authentication) {
+        User user = authenticationHelper.getAuthenticatedUser(authentication);
         log.info("User {} requested all warehouses", user.getEmail());
         ItemEntity item = warehouseService.updatedItemsToWarehouseLocation(warehouseLocationRequest, itemId, user);
         ItemResponse response = itemResponseToItemMapper.mapToItem(item);

--- a/src/main/java/com/example/maghouse/delivery/DeliveryService.java
+++ b/src/main/java/com/example/maghouse/delivery/DeliveryService.java
@@ -1,5 +1,6 @@
 package com.example.maghouse.delivery;
 
+import com.example.maghouse.auth.registration.user.User;
 import com.example.maghouse.auth.registration.user.UserRepository;
 import com.example.maghouse.delivery.status.DeliveryStatus;
 import com.example.maghouse.delivery.status.DeliveryStatusRequest;
@@ -10,9 +11,6 @@ import com.example.maghouse.warehouse.WarehouseService;
 import com.example.maghouse.warehouse.location.WarehouseLocation;
 import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -59,14 +57,7 @@ public class DeliveryService {
     }
 
     @Transactional
-    public DeliveryEntity createDelivery(DeliveryRequest deliveryRequest) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated()) {
-            throw new SecurityException("User is not authenticated");
-        }
-        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
-        var user = userRepository.findUserByEmail(userDetails.getUsername())
-                .orElseThrow(() -> new IllegalArgumentException("User with email not found!"));
+    public DeliveryEntity createDelivery(DeliveryRequest deliveryRequest, User user) {
         LocalDate data = LocalDate.now();
         String numberDelivery = deliveryNumberGenerator.generateDeliveryNumber();
         if (numberDelivery == null) {
@@ -83,13 +74,6 @@ public class DeliveryService {
     }
 
     public DeliveryEntity updateDeliveryStatus(DeliveryStatusRequest deliveryStatusRequest, Long id) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated()) {
-            throw new SecurityException("User is not authenticated");
-        }
-        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
-        var user = userRepository.findUserByEmail(userDetails.getUsername())
-                .orElseThrow(() -> new IllegalArgumentException("User with email not found!"));
         var delivery = deliveryRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Delivery not found!"));
         delivery.setDeliveryStatus(deliveryStatusRequest.getDeliveryStatus());

--- a/src/main/java/com/example/maghouse/item/ItemService.java
+++ b/src/main/java/com/example/maghouse/item/ItemService.java
@@ -33,6 +33,9 @@ public class ItemService {
 
     @Transactional
     public ItemEntity createItem(ItemRequest itemRequest, User user) {
+        if (user == null) {
+            throw new IllegalArgumentException("User cannot be null");
+        }
         String code = itemCodeGenerator.generateItemCode();
 
         ItemResponse itemResponse = itemResponseToItemMapper.mapToItemResponseFromRequest(itemRequest, code, null, user.getId() );

--- a/src/main/java/com/example/maghouse/item/ItemService.java
+++ b/src/main/java/com/example/maghouse/item/ItemService.java
@@ -5,9 +5,7 @@ import com.example.maghouse.auth.registration.user.User;
 import com.example.maghouse.auth.registration.user.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -15,6 +13,7 @@ import java.util.NoSuchElementException;
 
 @Service
 @AllArgsConstructor
+@Slf4j
 public class ItemService {
 
     private final UserRepository userRepository;
@@ -33,14 +32,7 @@ public class ItemService {
     }
 
     @Transactional
-    public ItemEntity createItem(ItemRequest itemRequest) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated()) {
-            throw new SecurityException("User is not authenticated");
-        }
-        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
-        User user = userRepository.findUserByEmail(userDetails.getUsername())
-                .orElseThrow(() -> new IllegalArgumentException("User with email not found"));
+    public ItemEntity createItem(ItemRequest itemRequest, User user) {
         String code = itemCodeGenerator.generateItemCode();
 
         ItemResponse itemResponse = itemResponseToItemMapper.mapToItemResponseFromRequest(itemRequest, code, null, user.getId() );
@@ -49,15 +41,7 @@ public class ItemService {
         return itemRepository.save(item);
     }
 
-    public ItemEntity updateItemQuantity(Long itemId, ItemRequest itemRequest) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated()) {
-            throw new SecurityException("User is not authenticated");
-        }
-        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
-        User user = userRepository.findUserByEmail(userDetails.getUsername())
-                .orElseThrow(() -> new IllegalArgumentException("User with email not found"));
-
+    public ItemEntity updateItemQuantity(Long itemId, ItemRequest itemRequest, User user) {
         ItemEntity item = itemRepository.findById(itemId)
                 .orElseThrow(() -> new IllegalArgumentException("Item not found"));
 
@@ -66,15 +50,7 @@ public class ItemService {
         return itemRepository.save(item);
     }
 
-    public void deleteItem(Long itemId) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated()) {
-            throw new SecurityException("User is not authenticated");
-        }
-        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
-        userRepository.findUserByEmail(userDetails.getUsername())
-                .orElseThrow(() -> new IllegalArgumentException("User with email not found"));
-
+    public void deleteItem(Long itemId, User user) {
         itemRepository.deleteById(itemId);
     }
 }

--- a/src/main/java/com/example/maghouse/security/AuthenticationHelper.java
+++ b/src/main/java/com/example/maghouse/security/AuthenticationHelper.java
@@ -1,22 +1,20 @@
-package com.example.maghouse.auth.controller;
+package com.example.maghouse.security;
 
 import com.example.maghouse.auth.registration.user.User;
 import com.example.maghouse.auth.registration.user.UserService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
 
+@Component
+@RequiredArgsConstructor
 @Slf4j
-public abstract class BaseController {
+public class AuthenticationHelper {
 
-    protected final UserService userService;
+    private final UserService userService;
 
-    protected BaseController(UserService userService) {
-        this.userService = userService;
-    }
-
-    protected User getAuthenticatedUser() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    public User getAuthenticatedUser(Authentication authentication) {
         if (authentication == null || !authentication.isAuthenticated()) {
             log.warn("Authentication failed - user not authenticated!");
             throw new SecurityException("Authentication failed - user not authenticated!");

--- a/src/main/java/com/example/maghouse/warehouse/WarehouseService.java
+++ b/src/main/java/com/example/maghouse/warehouse/WarehouseService.java
@@ -32,7 +32,7 @@ public class WarehouseService {
         return warehouseRepository.findAll();
     }
 
-    public List<ItemEntity> getAllItemsByLocationCodePrefix(WarehouseLocation warehouseLocation){
+    public List<ItemEntity> getAllItemsByLocationCodePrefix(WarehouseLocation warehouseLocation) {
         String prefix = generateLocationPrefix(warehouseLocation);
         return itemRepository.findByItemLocationStartingWith(prefix);
 
@@ -99,8 +99,8 @@ public class WarehouseService {
 
         ItemEntity item = itemRepository.findUnassignedItem(id)
                 .orElseThrow(() -> {
-                  LOGGER.warn("Attempted to access item {} that already has location code", id);
-                  return new IllegalArgumentException("Item already has a locationCode!");
+                    LOGGER.warn("Attempted to access item {} that already has location code", id);
+                    return new IllegalArgumentException("Item already has a locationCode!");
                 });
 
         String baseLocation = generateBaseCodeSpaceType(warehouseSpaceTypeRequest.getWarehouseSpaceType());
@@ -108,30 +108,21 @@ public class WarehouseService {
         Optional<String> locationCode = findAvailableSpace(STARTING_LOCATION_PREFIX, baseLocation, usedSpaces);
 
         return locationCode
-            .map(lc -> {
-               item.setLocationCode(lc);
-               item.setUser(user);
-               LOGGER.info("Successfully assigned locationCode={} to itemId={} for userId={}",
-                   locationCode, item.getId(), user.getId());
-               return item;
-            })
-           .orElseThrow(() -> {
-              LOGGER.info("Not implemented yet. TODO | FIXME");
-              return new IllegalArgumentException("Unable to assign location code!");
-            });
-    }
-
-    public User getUserByEmail(String email) {
-        LOGGER.debug("Looking up user by email: {}", email);
-        return userRepository.findUserByEmail(email)
+                .map(lc -> {
+                    item.setLocationCode(lc);
+                    item.setUser(user);
+                    LOGGER.info("Successfully assigned locationCode={} to itemId={} for userId={}",
+                            locationCode, item.getId(), user.getId());
+                    return item;
+                })
                 .orElseThrow(() -> {
-                    LOGGER.warn("User not found in database! Email: {}", email);
-                    return new IllegalArgumentException("User with email not found: " + email);
+                    LOGGER.info("Not implemented yet. TODO | FIXME");
+                    return new IllegalArgumentException("Unable to assign location code!");
                 });
     }
 
     public WarehouseLocation getWarehouseLocationByPrefix(String prefix) {
-        for(WarehouseLocation location : WarehouseLocation.values()) {
+        for (WarehouseLocation location : WarehouseLocation.values()) {
             String locationPrefix = generateLocationPrefix(location);
             if (locationPrefix.equals(prefix.toUpperCase())) {
                 return location;
@@ -139,23 +130,6 @@ public class WarehouseService {
         }
         throw new IllegalArgumentException("Unknow location prefix: " + prefix);
     }
-
-    //will delete after transfer
-   /* private User getAthenticatedUser() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated()) {
-            LOGGER.warn("Authentication failed - user not authenticated!");
-            throw new SecurityException("User is not authenticated!");
-        }
-        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
-        LOGGER.debug("User authenticated : {}", userDetails.getUsername());
-        return userRepository.findUserByEmail(userDetails.getUsername())
-                .orElseThrow(() -> {
-                    LOGGER.warn("User not found in database! Email: {}", userDetails.getUsername());
-                    return new IllegalArgumentException("User with email not found: " + userDetails.getUsername());
-
-                });
-    }*/
 
     private ItemEntity getItemById(Long id, User user) {
         return itemRepository.findById(id)
@@ -171,7 +145,7 @@ public class WarehouseService {
         List<ItemEntity> items = itemRepository.findByItemLocationStartingWith(locationPrefix);
         if (items.isEmpty()) {
             LOGGER.warn("No items found for location Prefix while creating warehouse." +
-                        "Location: {}, Prefix: {}, User: {}",
+                            "Location: {}, Prefix: {}, User: {}",
                     warehouseRequest.getWarehouseLocation(), locationPrefix, user.getId());
             throw new IllegalArgumentException("No items found for location prefix: " + locationPrefix);
         }
@@ -251,11 +225,11 @@ public class WarehouseService {
     }
 
     private Optional<String> findAvailableSpace(String locationPrefix,
-                                      String baseLocation,
-                                      Set<String> spaceUsage) {
+                                                String baseLocation,
+                                                Set<String> spaceUsage) {
         char[] positions = {'A', 'B', 'C'};
 
-        for (int index = 1; index <= 50 ; index++) {
+        for (int index = 1; index <= 50; index++) {
             for (char position : positions) {
                 String locationCode = String.format("%s%s%02d%c", locationPrefix, baseLocation, index, position);
                 if (!spaceUsage.contains(locationCode)) {

--- a/src/main/java/com/example/maghouse/warehouse/WarehouseService.java
+++ b/src/main/java/com/example/maghouse/warehouse/WarehouseService.java
@@ -13,9 +13,6 @@ import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
@@ -42,8 +39,7 @@ public class WarehouseService {
     }
 
     @Transactional
-    public WarehouseEntity createWarehouse(WarehouseRequest warehouseRequest) {
-        User user = getAthenticatedUser();
+    public WarehouseEntity createWarehouse(WarehouseRequest warehouseRequest, User user) {
         LOGGER.info("Request to create warehouse: userId={}, location={}",
                 user.getId(), warehouseRequest.getWarehouseLocation());
         String locationPrefix = generateLocationPrefix(warehouseRequest.getWarehouseLocation());
@@ -66,8 +62,7 @@ public class WarehouseService {
     }
 
     @Transactional
-    public ItemEntity assignItemsToWarehouseLocation(WarehouseLocationRequest warehouseLocationRequest, Long itemId) {
-        User user = getAthenticatedUser();
+    public ItemEntity assignItemsToWarehouseLocation(WarehouseLocationRequest warehouseLocationRequest, Long itemId, User user) {
         LOGGER.info("Request to add space type to Item: itemId = {}, location = {}",
                 itemId, warehouseLocationRequest.getWarehouseLocation());
         ItemEntity item = getItemById(itemId, user);
@@ -82,8 +77,7 @@ public class WarehouseService {
     }
 
     @Transactional
-    public ItemEntity updatedItemsToWarehouseLocation(WarehouseLocationRequest warehouseLocationRequest, Long id) {
-        User user = getAthenticatedUser();
+    public ItemEntity updatedItemsToWarehouseLocation(WarehouseLocationRequest warehouseLocationRequest, Long id, User user) {
         LOGGER.info("Request to update location to Item: itemId = {}, location = {}",
                 id, warehouseLocationRequest.getWarehouseLocation());
         ItemEntity item = getItemById(id, user);
@@ -99,8 +93,7 @@ public class WarehouseService {
     }
 
     @Transactional
-    public ItemEntity assignWarehouseSpaceType(WarehouseSpaceTypeRequest warehouseSpaceTypeRequest, Long id) {
-        User user = getAthenticatedUser();
+    public ItemEntity assignWarehouseSpaceType(WarehouseSpaceTypeRequest warehouseSpaceTypeRequest, Long id, User user) {
         LOGGER.info("Request to add space type to Item: itemId = {}, spaceType = {}",
                 id, warehouseSpaceTypeRequest.getWarehouseSpaceType());
 
@@ -128,6 +121,15 @@ public class WarehouseService {
             });
     }
 
+    public User getUserByEmail(String email) {
+        LOGGER.debug("Looking up user by email: {}", email);
+        return userRepository.findUserByEmail(email)
+                .orElseThrow(() -> {
+                    LOGGER.warn("User not found in database! Email: {}", email);
+                    return new IllegalArgumentException("User with email not found: " + email);
+                });
+    }
+
     public WarehouseLocation getWarehouseLocationByPrefix(String prefix) {
         for(WarehouseLocation location : WarehouseLocation.values()) {
             String locationPrefix = generateLocationPrefix(location);
@@ -138,7 +140,8 @@ public class WarehouseService {
         throw new IllegalArgumentException("Unknow location prefix: " + prefix);
     }
 
-    private User getAthenticatedUser() {
+    //will delete after transfer
+   /* private User getAthenticatedUser() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null || !authentication.isAuthenticated()) {
             LOGGER.warn("Authentication failed - user not authenticated!");
@@ -152,7 +155,7 @@ public class WarehouseService {
                     return new IllegalArgumentException("User with email not found: " + userDetails.getUsername());
 
                 });
-    }
+    }*/
 
     private ItemEntity getItemById(Long id, User user) {
         return itemRepository.findById(id)

--- a/src/main/java/com/example/maghouse/warehouse/WarehouseService.java
+++ b/src/main/java/com/example/maghouse/warehouse/WarehouseService.java
@@ -40,6 +40,9 @@ public class WarehouseService {
 
     @Transactional
     public WarehouseEntity createWarehouse(WarehouseRequest warehouseRequest, User user) {
+        if (user == null) {
+            throw new IllegalArgumentException("User cannot be null");
+        }
         LOGGER.info("Request to create warehouse: userId={}, location={}",
                 user.getId(), warehouseRequest.getWarehouseLocation());
         String locationPrefix = generateLocationPrefix(warehouseRequest.getWarehouseLocation());
@@ -63,6 +66,9 @@ public class WarehouseService {
 
     @Transactional
     public ItemEntity assignItemsToWarehouseLocation(WarehouseLocationRequest warehouseLocationRequest, Long itemId, User user) {
+        if (user == null) {
+            throw new IllegalArgumentException("User cannot be null");
+        }
         LOGGER.info("Request to add space type to Item: itemId = {}, location = {}",
                 itemId, warehouseLocationRequest.getWarehouseLocation());
         ItemEntity item = getItemById(itemId, user);
@@ -78,6 +84,9 @@ public class WarehouseService {
 
     @Transactional
     public ItemEntity updatedItemsToWarehouseLocation(WarehouseLocationRequest warehouseLocationRequest, Long id, User user) {
+        if (user == null) {
+            throw new IllegalArgumentException("User cannot be null");
+        }
         LOGGER.info("Request to update location to Item: itemId = {}, location = {}",
                 id, warehouseLocationRequest.getWarehouseLocation());
         ItemEntity item = getItemById(id, user);

--- a/src/test/java/com/example/maghouse/auth/controller/DeliveryControllerTest.java
+++ b/src/test/java/com/example/maghouse/auth/controller/DeliveryControllerTest.java
@@ -96,7 +96,7 @@ public class DeliveryControllerTest {
                 .user(user)
                 .item(null)
                 .build();
-        when(deliveryService.createDelivery(request)).thenReturn(exceptedDelivery);
+        when(deliveryService.createDelivery(request, user)).thenReturn(exceptedDelivery);
         when(deliveryResponseToDeliveryMapper.mapToResponse(any(DeliveryEntity.class))).thenReturn(new DeliveryResponse());
 
         ResponseEntity<DeliveryResponse> result = deliveryController.create(request);
@@ -104,13 +104,13 @@ public class DeliveryControllerTest {
         assertNotNull(result);
         assertEquals(HttpStatus.CREATED, result.getStatusCode());
         assertEquals(new DeliveryResponse(), result.getBody());
-        verify(deliveryService).createDelivery(request);
+        verify(deliveryService).createDelivery(request, user);
     }
 
     @Test
     void shouldThrowExceptionWhenCreatingDeliveryWithNullRequest(){
         assertThrows(IllegalArgumentException.class, () -> deliveryController.create(null));
-        verify(deliveryService, never()).createDelivery(any());
+        verify(deliveryService, never()).createDelivery(any(), user);
     }
 
     @Test

--- a/src/test/java/com/example/maghouse/auth/controller/DeliveryControllerTest.java
+++ b/src/test/java/com/example/maghouse/auth/controller/DeliveryControllerTest.java
@@ -2,7 +2,6 @@ package com.example.maghouse.auth.controller;
 
 import com.example.maghouse.auth.registration.role.Role;
 import com.example.maghouse.auth.registration.user.User;
-import com.example.maghouse.auth.registration.user.UserRepository;
 import com.example.maghouse.delivery.DeliveryEntity;
 import com.example.maghouse.delivery.DeliveryRequest;
 import com.example.maghouse.delivery.DeliveryResponse;
@@ -10,59 +9,44 @@ import com.example.maghouse.delivery.DeliveryService;
 import com.example.maghouse.delivery.status.DeliveryStatus;
 import com.example.maghouse.delivery.status.DeliveryStatusRequest;
 import com.example.maghouse.mapper.DeliveryResponseToDeliveryMapper;
+import com.example.maghouse.security.AuthenticationHelper;
 import com.example.maghouse.warehouse.location.WarehouseLocation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 
 import java.sql.Date;
 import java.time.LocalDate;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-public class DeliveryControllerTest {
+@ExtendWith(MockitoExtension.class)
+class DeliveryControllerTest {
 
     @Mock
     private DeliveryResponseToDeliveryMapper deliveryResponseToDeliveryMapper;
+
     @Mock
     private DeliveryService deliveryService;
 
     @Mock
-    private UserRepository userRepository;
-
-    @Mock
-    private UserDetails userDetails;
-
-    @Mock
-    private SecurityContext securityContext;
-
-    @Mock
-    private Authentication authentication;
+    private AuthenticationHelper authenticationHelper;
 
     @InjectMocks
     private DeliveryController deliveryController;
 
     private User user;
+    private Authentication authentication;
 
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.openMocks(this);
-
-        SecurityContextHolder.setContext(securityContext);
-        lenient().when(securityContext.getAuthentication()).thenReturn(authentication);
-        lenient().when(authentication.isAuthenticated()).thenReturn(true);
-        lenient().when(authentication.getPrincipal()).thenReturn(userDetails);
-
         user = User.builder()
                 .id(1L)
                 .firstname("John")
@@ -72,8 +56,9 @@ public class DeliveryControllerTest {
                 .role(Role.MANAGER)
                 .build();
 
-        lenient().when(userDetails.getUsername()).thenReturn(user.getEmail());
-        lenient().when(userRepository.findUserByEmail(user.getEmail())).thenReturn(Optional.of(user));
+        authentication = mock(Authentication.class);
+
+        lenient().when(authenticationHelper.getAuthenticatedUser(authentication)).thenReturn(user);
     }
 
     @Test
@@ -96,21 +81,24 @@ public class DeliveryControllerTest {
                 .user(user)
                 .item(null)
                 .build();
+
         when(deliveryService.createDelivery(request, user)).thenReturn(exceptedDelivery);
         when(deliveryResponseToDeliveryMapper.mapToResponse(any(DeliveryEntity.class))).thenReturn(new DeliveryResponse());
 
-        ResponseEntity<DeliveryResponse> result = deliveryController.create(request);
+        ResponseEntity<DeliveryResponse> result = deliveryController.create(request, authentication);
 
         assertNotNull(result);
         assertEquals(HttpStatus.CREATED, result.getStatusCode());
         assertEquals(new DeliveryResponse(), result.getBody());
+        verify(authenticationHelper).getAuthenticatedUser(authentication);
         verify(deliveryService).createDelivery(request, user);
     }
 
     @Test
     void shouldThrowExceptionWhenCreatingDeliveryWithNullRequest(){
-        assertThrows(IllegalArgumentException.class, () -> deliveryController.create(null));
-        verify(deliveryService, never()).createDelivery(any(), user);
+        assertThrows(IllegalArgumentException.class, () -> deliveryController.create(null, authentication));
+        verify(authenticationHelper).getAuthenticatedUser(authentication);
+        verify(deliveryService, never()).createDelivery(any(), any());
     }
 
     @Test
@@ -131,11 +119,13 @@ public class DeliveryControllerTest {
                 .build();
 
         when(deliveryService.updateDeliveryStatus(deliveryStatusRequest, id)).thenReturn(updatedDelivery);
+        when(deliveryResponseToDeliveryMapper.mapToResponse(updatedDelivery)).thenReturn(new DeliveryResponse());
 
-        ResponseEntity<DeliveryResponse> result = deliveryController.updateDeliveryStatus(deliveryStatusRequest, id);
+        ResponseEntity<DeliveryResponse> result = deliveryController.updateDeliveryStatus(deliveryStatusRequest, id, authentication);
 
         assertNotNull(result);
         assertEquals(HttpStatus.OK, result.getStatusCode());
+        verify(authenticationHelper).getAuthenticatedUser(authentication);
         verify(deliveryService).updateDeliveryStatus(deliveryStatusRequest, id);
     }
 
@@ -148,20 +138,22 @@ public class DeliveryControllerTest {
                 .thenThrow(new RuntimeException("Delivery not found!"));
 
         RuntimeException exception = assertThrows(RuntimeException.class, () ->
-                deliveryController.updateDeliveryStatus(deliveryStatusRequest, id)
+                deliveryController.updateDeliveryStatus(deliveryStatusRequest, id, authentication)
         );
 
         assertEquals("Delivery not found!", exception.getMessage());
+        verify(authenticationHelper).getAuthenticatedUser(authentication);
         verify(deliveryService).updateDeliveryStatus(deliveryStatusRequest, id);
     }
 
     @Test
-    void shouldThrowExceptionWhenUpdateDeliveryStatusRequestIsNull() throws Exception{
+    void shouldThrowExceptionWhenUpdateDeliveryStatusRequestIsNull() {
         Long id = 1L;
 
         assertThrows(IllegalArgumentException.class, () ->
-                deliveryController.updateDeliveryStatus(null, id));
+                deliveryController.updateDeliveryStatus(null, id, authentication));
 
+        verify(authenticationHelper).getAuthenticatedUser(authentication);
         verify(deliveryService, never()).updateDeliveryStatus(any(), any());
     }
 
@@ -170,13 +162,14 @@ public class DeliveryControllerTest {
         DeliveryStatusRequest deliveryStatusRequest = new DeliveryStatusRequest(DeliveryStatus.DELIVERED);
 
         assertThrows(IllegalArgumentException.class, () ->
-                deliveryController.updateDeliveryStatus(deliveryStatusRequest, null));
+                deliveryController.updateDeliveryStatus(deliveryStatusRequest, null, authentication));
 
+        verify(authenticationHelper).getAuthenticatedUser(authentication);
         verify(deliveryService, never()).updateDeliveryStatus(any(), any());
     }
 
+    @Test
     void shouldThrowAllExceptionsWhenUserIsNotAuthenticated(){
-        when(securityContext.getAuthentication()).thenReturn(null);
 
         DeliveryRequest deliveryRequest = new DeliveryRequest(
                 "inpost",
@@ -185,19 +178,16 @@ public class DeliveryControllerTest {
                 100
         );
 
-        assertDoesNotThrow(() -> deliveryController.create(deliveryRequest));
+        assertDoesNotThrow(() -> deliveryController.create(deliveryRequest, authentication));
 
         Long id = 1L;
         DeliveryStatusRequest deliveryStatusRequest = new DeliveryStatusRequest(DeliveryStatus.IN_PROGRESS);
 
-        assertDoesNotThrow(() -> deliveryController.updateDeliveryStatus(deliveryStatusRequest, id));
+        assertDoesNotThrow(() -> deliveryController.updateDeliveryStatus(deliveryStatusRequest, id, authentication));
     }
 
     @Test
-    void shouldThrowAllExceptionsWhenUserNotFound(){
-        when(userDetails.getUsername()).thenReturn(user.getEmail());
-        when(userRepository.findUserByEmail(user.getEmail())).thenReturn(Optional.empty());
-
+    void shouldThrowExceptionWhenAuthenticationHelperThrowsSecurityException() {
         DeliveryRequest deliveryRequest = new DeliveryRequest(
                 "inpost",
                 "ItemName",
@@ -205,11 +195,12 @@ public class DeliveryControllerTest {
                 100
         );
 
-        assertDoesNotThrow(() -> deliveryController.create(deliveryRequest));
+        when(authenticationHelper.getAuthenticatedUser(authentication))
+                .thenThrow(new SecurityException("Authentication failed"));
 
-        Long id = 1L;
-        DeliveryStatusRequest deliveryStatusRequest = new DeliveryStatusRequest(DeliveryStatus.IN_PROGRESS);
-
-        assertDoesNotThrow(() -> deliveryController.updateDeliveryStatus(deliveryStatusRequest, id));
+        assertThrows(SecurityException.class, () ->
+                deliveryController.create(deliveryRequest, authentication)
+        );
     }
+
 }

--- a/src/test/java/com/example/maghouse/auth/controller/ItemControllerTest.java
+++ b/src/test/java/com/example/maghouse/auth/controller/ItemControllerTest.java
@@ -63,7 +63,7 @@ public class ItemControllerTest {
 
     @Test
     void shouldCreateItemSuccessfully(){
-        when(itemService.createItem(itemRequest)).thenReturn(item);
+        when(itemService.createItem(itemRequest, user)).thenReturn(item);
         when(itemResponseToItemMapper.mapToItem(item)).thenReturn(new ItemResponse());
 
         ResponseEntity<ItemResponse> response = itemController.create(itemRequest);
@@ -75,7 +75,7 @@ public class ItemControllerTest {
 
     @Test
     void shouldThrowExceptionWhenCreatingItemWithNullRequest(){
-        when(itemService.createItem(null)).thenThrow(new IllegalArgumentException("ItemRequest can't be empty!"));
+        when(itemService.createItem(null, user)).thenThrow(new IllegalArgumentException("ItemRequest can't be empty!"));
 
         assertThrows(IllegalArgumentException.class, () -> itemController.create(null));
     }
@@ -84,7 +84,7 @@ public class ItemControllerTest {
     void shouldUpdatedItemQuantity(){
         ItemRequest updatedItemRequest = new ItemRequest("Test_Item", 140);
 
-        when(itemService.updateItemQuantity(item.getId(),updatedItemRequest)).thenReturn(item);
+        when(itemService.updateItemQuantity(item.getId(),updatedItemRequest, user)).thenReturn(item);
         when(itemResponseToItemMapper.mapToItem(item)).thenReturn(new ItemResponse());
 
         ResponseEntity<ItemResponse> response = itemController.updateItemQuantity(item.getId(), updatedItemRequest);
@@ -100,7 +100,7 @@ public class ItemControllerTest {
     void shouldThrowExceptionWhenUpdatingNonExistentItem(){
         ItemRequest wrongItemRequest = new ItemRequest("Item1", 35);
 
-        when(itemService.updateItemQuantity(1L, wrongItemRequest)).thenThrow(new ResponseStatusException(NOT_FOUND, "Item not found!"));
+        when(itemService.updateItemQuantity(1L, wrongItemRequest, user)).thenThrow(new ResponseStatusException(NOT_FOUND, "Item not found!"));
 
         assertThrows(ResponseStatusException.class, () -> itemController.updateItemQuantity(1L, wrongItemRequest));
 
@@ -108,7 +108,7 @@ public class ItemControllerTest {
 
     @Test
     void shouldDeleteItemSuccessfully(){
-        doNothing().when(itemService).deleteItem(1L);
+        doNothing().when(itemService).deleteItem(1L, user);
 
         ResponseEntity<Void> response = itemController.deleteItem(1L);
 
@@ -117,7 +117,7 @@ public class ItemControllerTest {
 
     @Test
     void shouldThrowExceptionWhenDeletingNonExistentItem(){
-        doThrow(new ResponseStatusException(NOT_FOUND, "Item not found")).when(itemService).deleteItem(1L);
+        doThrow(new ResponseStatusException(NOT_FOUND, "Item not found")).when(itemService).deleteItem(1L, user);
 
         assertThrows(ResponseStatusException.class, () -> itemController.deleteItem(1L));
     }

--- a/src/test/java/com/example/maghouse/auth/controller/ItemControllerTest.java
+++ b/src/test/java/com/example/maghouse/auth/controller/ItemControllerTest.java
@@ -7,19 +7,23 @@ import com.example.maghouse.item.ItemRequest;
 import com.example.maghouse.item.ItemResponse;
 import com.example.maghouse.item.ItemService;
 import com.example.maghouse.mapper.ItemResponseToItemMapper;
+import com.example.maghouse.security.AuthenticationHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.server.ResponseStatusException;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.http.HttpStatus.*;
 
-public class ItemControllerTest {
+@ExtendWith(MockitoExtension.class)
+class ItemControllerTest {
 
     @Mock
     private ItemResponseToItemMapper itemResponseToItemMapper;
@@ -27,17 +31,19 @@ public class ItemControllerTest {
     @Mock
     private ItemService itemService;
 
+    @Mock
+    private AuthenticationHelper authenticationHelper;
+
     @InjectMocks
     private ItemController itemController;
 
     private ItemEntity item;
     private ItemRequest itemRequest;
     private User user;
+    private Authentication authentication;
 
     @BeforeEach
     void setUp(){
-        MockitoAnnotations.openMocks(this);
-
         user = User.builder()
                 .firstname("John")
                 .lastname("Kovalsky")
@@ -45,6 +51,11 @@ public class ItemControllerTest {
                 .password("testPassword")
                 .role(Role.USER)
                 .build();
+
+        authentication = mock(Authentication.class);
+        lenient().when(authentication.getName()).thenReturn(user.getEmail());
+        lenient().when(authentication.isAuthenticated()).thenReturn(true);
+        lenient().when(authenticationHelper.getAuthenticatedUser(authentication)).thenReturn(user);
 
         itemRequest = new ItemRequest("Test_Item", 100);
 
@@ -66,60 +77,70 @@ public class ItemControllerTest {
         when(itemService.createItem(itemRequest, user)).thenReturn(item);
         when(itemResponseToItemMapper.mapToItem(item)).thenReturn(new ItemResponse());
 
-        ResponseEntity<ItemResponse> response = itemController.create(itemRequest);
+        ResponseEntity<ItemResponse> response = itemController.create(itemRequest, authentication);
 
         assertNotNull(response);
         assertEquals(CREATED, response.getStatusCode());
         assertEquals(new ItemResponse(), response.getBody());
+        verify(authenticationHelper).getAuthenticatedUser(authentication);
+        verify(itemService).createItem(itemRequest, user);
     }
 
     @Test
     void shouldThrowExceptionWhenCreatingItemWithNullRequest(){
+        when(authenticationHelper.getAuthenticatedUser(authentication)).thenReturn(user);
         when(itemService.createItem(null, user)).thenThrow(new IllegalArgumentException("ItemRequest can't be empty!"));
 
-        assertThrows(IllegalArgumentException.class, () -> itemController.create(null));
+        assertThrows(IllegalArgumentException.class, () -> itemController.create(null, authentication));
+        verify(authenticationHelper).getAuthenticatedUser(authentication);
     }
 
     @Test
     void shouldUpdatedItemQuantity(){
         ItemRequest updatedItemRequest = new ItemRequest("Test_Item", 140);
 
-        when(itemService.updateItemQuantity(item.getId(),updatedItemRequest, user)).thenReturn(item);
+        when(authenticationHelper.getAuthenticatedUser(authentication)).thenReturn(user);
+        when(itemService.updateItemQuantity(item.getId(), updatedItemRequest, user)).thenReturn(item);
         when(itemResponseToItemMapper.mapToItem(item)).thenReturn(new ItemResponse());
 
-        ResponseEntity<ItemResponse> response = itemController.updateItemQuantity(item.getId(), updatedItemRequest);
-
+        ResponseEntity<ItemResponse> response = itemController.updateItemQuantity(item.getId(), updatedItemRequest, authentication);
 
         assertNotNull(response);
         assertEquals(OK , response.getStatusCode());
         assertEquals(new ItemResponse(), response.getBody());
-
+        verify(authenticationHelper).getAuthenticatedUser(authentication);
+        verify(itemService).updateItemQuantity(item.getId(), updatedItemRequest, user);
     }
 
     @Test
     void shouldThrowExceptionWhenUpdatingNonExistentItem(){
         ItemRequest wrongItemRequest = new ItemRequest("Item1", 35);
 
+        when(authenticationHelper.getAuthenticatedUser(authentication)).thenReturn(user);
         when(itemService.updateItemQuantity(1L, wrongItemRequest, user)).thenThrow(new ResponseStatusException(NOT_FOUND, "Item not found!"));
 
-        assertThrows(ResponseStatusException.class, () -> itemController.updateItemQuantity(1L, wrongItemRequest));
-
+        assertThrows(ResponseStatusException.class, () -> itemController.updateItemQuantity(1L, wrongItemRequest, authentication));
+        verify(authenticationHelper).getAuthenticatedUser(authentication);
     }
 
     @Test
     void shouldDeleteItemSuccessfully(){
+        when(authenticationHelper.getAuthenticatedUser(authentication)).thenReturn(user);
         doNothing().when(itemService).deleteItem(1L, user);
 
-        ResponseEntity<Void> response = itemController.deleteItem(1L);
+        ResponseEntity<Void> response = itemController.deleteItem(1L, authentication);
 
         assertEquals(NO_CONTENT, response.getStatusCode());
+        verify(authenticationHelper).getAuthenticatedUser(authentication);
+        verify(itemService).deleteItem(1L, user);
     }
 
     @Test
     void shouldThrowExceptionWhenDeletingNonExistentItem(){
+        when(authenticationHelper.getAuthenticatedUser(authentication)).thenReturn(user);
         doThrow(new ResponseStatusException(NOT_FOUND, "Item not found")).when(itemService).deleteItem(1L, user);
 
-        assertThrows(ResponseStatusException.class, () -> itemController.deleteItem(1L));
+        assertThrows(ResponseStatusException.class, () -> itemController.deleteItem(1L, authentication));
+        verify(authenticationHelper).getAuthenticatedUser(authentication);
     }
-
 }

--- a/src/test/java/com/example/maghouse/auth/controller/WarehouseControllerTest.java
+++ b/src/test/java/com/example/maghouse/auth/controller/WarehouseControllerTest.java
@@ -2,11 +2,11 @@ package com.example.maghouse.auth.controller;
 
 import com.example.maghouse.auth.registration.role.Role;
 import com.example.maghouse.auth.registration.user.User;
-import com.example.maghouse.auth.registration.user.UserRepository;
 import com.example.maghouse.item.ItemEntity;
 import com.example.maghouse.item.ItemResponse;
 import com.example.maghouse.mapper.ItemResponseToItemMapper;
 import com.example.maghouse.mapper.WarehouseResponseToWarehouseMapper;
+import com.example.maghouse.security.AuthenticationHelper;
 import com.example.maghouse.warehouse.WarehouseEntity;
 import com.example.maghouse.warehouse.WarehouseRequest;
 import com.example.maghouse.warehouse.WarehouseResponse;
@@ -17,24 +17,22 @@ import com.example.maghouse.warehouse.spacetype.WarehouseSpaceType;
 import com.example.maghouse.warehouse.spacetype.WarehouseSpaceTypeRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-public class WarehouseControllerTest {
+@ExtendWith(MockitoExtension.class)
+class WarehouseControllerTest {
 
     @Mock
     private ItemResponseToItemMapper itemResponseToItemMapper;
@@ -46,31 +44,16 @@ public class WarehouseControllerTest {
     private WarehouseService warehouseService;
 
     @Mock
-    private UserRepository userRepository;
-
-    @Mock
-    private UserDetails userDetails;
-
-    @Mock
-    private SecurityContext securityContext;
-
-    @Mock
-    private Authentication authentication;
+    private AuthenticationHelper authenticationHelper;
 
     @InjectMocks
     private WarehouseController warehouseController;
 
     private User user;
+    private Authentication authentication;
 
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.openMocks(this);
-
-        SecurityContextHolder.setContext(securityContext);
-        lenient().when(securityContext.getAuthentication()).thenReturn(authentication);
-        lenient().when(authentication.isAuthenticated()).thenReturn(true);
-        lenient().when(authentication.getPrincipal()).thenReturn(userDetails);
-
         user = User.builder()
                 .id(1L)
                 .firstname("John")
@@ -80,13 +63,15 @@ public class WarehouseControllerTest {
                 .role(Role.MANAGER)
                 .build();
 
-        lenient().when(userDetails.getUsername()).thenReturn(user.getEmail());
-        lenient().when(userRepository.findUserByEmail(user.getEmail())).thenReturn(Optional.of(user));
-
+        authentication = mock(Authentication.class);
+        lenient().when(authentication.getName()).thenReturn(user.getEmail());
+        lenient().when(authentication.isAuthenticated()).thenReturn(true);
+        lenient().when(authenticationHelper.getAuthenticatedUser(authentication)).thenReturn(user);
     }
 
     @Test
     void shouldCreateWarehouseWhenUserAuthenticated() {
+        // Given
         WarehouseRequest request = new WarehouseRequest(WarehouseLocation.Warsaw);
 
         WarehouseEntity warehouseEntity = WarehouseEntity.builder()
@@ -101,28 +86,29 @@ public class WarehouseControllerTest {
                 .itemsId(new ArrayList<>())
                 .build();
 
+        when(authenticationHelper.getAuthenticatedUser(authentication)).thenReturn(user);
         when(warehouseService.createWarehouse(request, user)).thenReturn(warehouseEntity);
         when(warehouseResponseToWarehouseMapper.mapToWarehouse(warehouseEntity)).thenReturn(warehouseResponse);
 
-        ResponseEntity<WarehouseResponse> result = warehouseController.create(request);
+        ResponseEntity<WarehouseResponse> result = warehouseController.create(request, authentication);
 
         assertEquals(HttpStatus.CREATED, result.getStatusCode());
         assertNotNull(result.getBody());
+        verify(authenticationHelper).getAuthenticatedUser(authentication);
         verify(warehouseService).createWarehouse(request, user);
         verify(warehouseResponseToWarehouseMapper).mapToWarehouse(warehouseEntity);
-
     }
 
     @Test
     void shouldThrowExceptionWhenCreateWarehouseFails() {
         WarehouseRequest warehouseRequest = new WarehouseRequest();
 
-        when(warehouseService.createWarehouse(warehouseRequest, user))
+        when(authenticationHelper.getAuthenticatedUser(authentication)).thenReturn(user);
+        when(warehouseService.createWarehouse(eq(warehouseRequest), eq(user)))
                 .thenThrow(new RuntimeException("Request not found!"));
 
-        assertThrows(RuntimeException.class, () -> warehouseController.create(warehouseRequest));
-        verify(warehouseService).createWarehouse(warehouseRequest, user);
-
+        assertThrows(RuntimeException.class, () -> warehouseController.create(warehouseRequest, authentication));
+        verify(authenticationHelper).getAuthenticatedUser(authentication);
     }
 
     @Test
@@ -137,40 +123,35 @@ public class WarehouseControllerTest {
                 .itemCode("itemCode")
                 .user(user)
                 .build();
-        WarehouseEntity warehouseEntity = WarehouseEntity.builder()
-                .id(1L)
-                .warehouseLocation(WarehouseLocation.Rzeszow)
-                .user(user)
-                .build();
 
-        WarehouseResponse warehouseResponse = WarehouseResponse.builder()
-                .userId(user.getId())
-                .itemsId(new ArrayList<>())
-                .build();
+        ItemResponse itemResponse = ItemResponse.builder().build();
 
+        when(authenticationHelper.getAuthenticatedUser(authentication)).thenReturn(user);
         when(warehouseService.assignWarehouseSpaceType(warehouseSpaceTypeRequest, item.getId(), user))
                 .thenReturn(item);
-        when(itemResponseToItemMapper.mapToItem(item)).thenReturn(new ItemResponse());
+        when(itemResponseToItemMapper.mapToItem(item)).thenReturn(itemResponse);
 
-        ItemResponse result = warehouseController.assignSpaceType(item.getId(), warehouseSpaceTypeRequest).getBody();
+        ResponseEntity<ItemResponse> responseEntity = warehouseController.assignSpaceType(item.getId(), warehouseSpaceTypeRequest, authentication);
+        ItemResponse result = responseEntity.getBody();
 
-        assertEquals(1L, item.getId());
+        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
         assertNotNull(result);
-        assertEquals(item.getLocationCode(), result.getLocationCode());
+        verify(authenticationHelper).getAuthenticatedUser(authentication);
         verify(warehouseService).assignWarehouseSpaceType(warehouseSpaceTypeRequest, item.getId(), user);
     }
 
     @Test
     void shouldThrowExceptionWhenAssignSpaceTypeFails() {
         Long id = 99L;
-
         WarehouseSpaceTypeRequest warehouseSpaceTypeRequest = new WarehouseSpaceTypeRequest();
 
-        when(warehouseService.assignWarehouseSpaceType(warehouseSpaceTypeRequest, id, user))
+        when(authenticationHelper.getAuthenticatedUser(authentication)).thenReturn(user);
+        when(warehouseService.assignWarehouseSpaceType(eq(warehouseSpaceTypeRequest), eq(id), eq(user)))
                 .thenThrow(new IllegalArgumentException("Item not found!"));
 
         assertThrows(IllegalArgumentException.class,
-                () -> warehouseController.assignSpaceType(id, warehouseSpaceTypeRequest));
+                () -> warehouseController.assignSpaceType(id, warehouseSpaceTypeRequest, authentication));
+        verify(authenticationHelper).getAuthenticatedUser(authentication);
         verify(warehouseService).assignWarehouseSpaceType(warehouseSpaceTypeRequest, id, user);
     }
 
@@ -196,6 +177,7 @@ public class WarehouseControllerTest {
                 .items(List.of(item))
                 .build();
 
+        when(authenticationHelper.getAuthenticatedUser(authentication)).thenReturn(user);
         when(warehouseService.assignItemsToWarehouseLocation(warehouseLocationRequest, item.getId(), user))
                 .thenReturn(item);
 
@@ -208,11 +190,14 @@ public class WarehouseControllerTest {
                 .build();
         when(itemResponseToItemMapper.mapToItem(item)).thenReturn(itemResponse);
 
-        ItemResponse result = warehouseController.assignWarehouseLocation(item.getId(), warehouseLocationRequest).getBody();
+        ResponseEntity<ItemResponse> responseEntity = warehouseController.assignWarehouseLocation(item.getId(), warehouseLocationRequest, authentication);
+        ItemResponse result = responseEntity.getBody();
 
+        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
         assertNotNull(result);
         assertEquals("RS05B", result.getLocationCode());
         assertEquals(user.getId(), result.getUserId());
+        verify(authenticationHelper).getAuthenticatedUser(authentication);
         verify(warehouseService).assignItemsToWarehouseLocation(warehouseLocationRequest, item.getId(), user);
     }
 
@@ -221,11 +206,13 @@ public class WarehouseControllerTest {
         Long id = 100L;
         WarehouseLocationRequest warehouseLocationRequest = new WarehouseLocationRequest();
 
-        when(warehouseService.assignItemsToWarehouseLocation(warehouseLocationRequest, id, user))
+        when(authenticationHelper.getAuthenticatedUser(authentication)).thenReturn(user);
+        when(warehouseService.assignItemsToWarehouseLocation(eq(warehouseLocationRequest), eq(id), eq(user)))
                 .thenThrow(new IllegalArgumentException("WarehouseEntity not found!!"));
 
         assertThrows(IllegalArgumentException.class,
-                () -> warehouseController.assignWarehouseLocation(id, warehouseLocationRequest));
+                () -> warehouseController.assignWarehouseLocation(id, warehouseLocationRequest, authentication));
+        verify(authenticationHelper).getAuthenticatedUser(authentication);
         verify(warehouseService).assignItemsToWarehouseLocation(warehouseLocationRequest, id, user);
     }
 
@@ -250,6 +237,7 @@ public class WarehouseControllerTest {
                 .items(List.of(updatedItem))
                 .build();
 
+        when(authenticationHelper.getAuthenticatedUser(authentication)).thenReturn(user);
         when(warehouseService.updatedItemsToWarehouseLocation(warehouseLocationRequest, itemId, user))
                 .thenReturn(updatedItem);
         updatedItem.setWarehouseEntity(warehouseEntity);
@@ -261,12 +249,14 @@ public class WarehouseControllerTest {
                 .build();
         when(itemResponseToItemMapper.mapToItem(updatedItem)).thenReturn(itemResponse);
 
-        ItemResponse result = warehouseController.updateWarehouseLocation(updatedItem.getId(), warehouseLocationRequest).getBody();
+        ResponseEntity<ItemResponse> responseEntity = warehouseController.updateWarehouseLocation(updatedItem.getId(), warehouseLocationRequest, authentication);
+        ItemResponse result = responseEntity.getBody();
 
+        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
         assertNotNull(result);
         assertEquals("KSO5B", result.getLocationCode());
         assertEquals(updatedItem.getItemCode(), result.getItemCode());
-
+        verify(authenticationHelper).getAuthenticatedUser(authentication);
         verify(warehouseService).updatedItemsToWarehouseLocation(warehouseLocationRequest, updatedItem.getId(), user);
     }
 
@@ -275,10 +265,12 @@ public class WarehouseControllerTest {
         Long id = 404L;
         WarehouseLocationRequest warehouseLocationRequest = new WarehouseLocationRequest();
 
-        when(warehouseService.updatedItemsToWarehouseLocation(warehouseLocationRequest, id, user))
+        when(authenticationHelper.getAuthenticatedUser(authentication)).thenReturn(user);
+        when(warehouseService.updatedItemsToWarehouseLocation(any(WarehouseLocationRequest.class), eq(id), eq(user)))
                 .thenThrow(new RuntimeException("Update failed!!"));
 
-        assertThrows(RuntimeException.class, () -> warehouseController.updateWarehouseLocation(id, warehouseLocationRequest));
+        assertThrows(RuntimeException.class, () -> warehouseController.updateWarehouseLocation(id, warehouseLocationRequest, authentication));
+        verify(authenticationHelper).getAuthenticatedUser(authentication);
         verify(warehouseService).updatedItemsToWarehouseLocation(warehouseLocationRequest, id, user);
     }
 }

--- a/src/test/java/com/example/maghouse/auth/controller/WarehouseControllerTest.java
+++ b/src/test/java/com/example/maghouse/auth/controller/WarehouseControllerTest.java
@@ -101,14 +101,14 @@ public class WarehouseControllerTest {
                 .itemsId(new ArrayList<>())
                 .build();
 
-        when(warehouseService.createWarehouse(request)).thenReturn(warehouseEntity);
+        when(warehouseService.createWarehouse(request, user)).thenReturn(warehouseEntity);
         when(warehouseResponseToWarehouseMapper.mapToWarehouse(warehouseEntity)).thenReturn(warehouseResponse);
 
         ResponseEntity<WarehouseResponse> result = warehouseController.create(request);
 
         assertEquals(HttpStatus.CREATED, result.getStatusCode());
         assertNotNull(result.getBody());
-        verify(warehouseService).createWarehouse(request);
+        verify(warehouseService).createWarehouse(request, user);
         verify(warehouseResponseToWarehouseMapper).mapToWarehouse(warehouseEntity);
 
     }
@@ -117,11 +117,11 @@ public class WarehouseControllerTest {
     void shouldThrowExceptionWhenCreateWarehouseFails() {
         WarehouseRequest warehouseRequest = new WarehouseRequest();
 
-        when(warehouseService.createWarehouse(warehouseRequest))
+        when(warehouseService.createWarehouse(warehouseRequest, user))
                 .thenThrow(new RuntimeException("Request not found!"));
 
         assertThrows(RuntimeException.class, () -> warehouseController.create(warehouseRequest));
-        verify(warehouseService).createWarehouse(warehouseRequest);
+        verify(warehouseService).createWarehouse(warehouseRequest, user);
 
     }
 
@@ -148,7 +148,7 @@ public class WarehouseControllerTest {
                 .itemsId(new ArrayList<>())
                 .build();
 
-        when(warehouseService.assignWarehouseSpaceType(warehouseSpaceTypeRequest, item.getId()))
+        when(warehouseService.assignWarehouseSpaceType(warehouseSpaceTypeRequest, item.getId(), user))
                 .thenReturn(item);
         when(itemResponseToItemMapper.mapToItem(item)).thenReturn(new ItemResponse());
 
@@ -157,7 +157,7 @@ public class WarehouseControllerTest {
         assertEquals(1L, item.getId());
         assertNotNull(result);
         assertEquals(item.getLocationCode(), result.getLocationCode());
-        verify(warehouseService).assignWarehouseSpaceType(warehouseSpaceTypeRequest, item.getId());
+        verify(warehouseService).assignWarehouseSpaceType(warehouseSpaceTypeRequest, item.getId(), user);
     }
 
     @Test
@@ -166,12 +166,12 @@ public class WarehouseControllerTest {
 
         WarehouseSpaceTypeRequest warehouseSpaceTypeRequest = new WarehouseSpaceTypeRequest();
 
-        when(warehouseService.assignWarehouseSpaceType(warehouseSpaceTypeRequest, id))
+        when(warehouseService.assignWarehouseSpaceType(warehouseSpaceTypeRequest, id, user))
                 .thenThrow(new IllegalArgumentException("Item not found!"));
 
         assertThrows(IllegalArgumentException.class,
                 () -> warehouseController.assignSpaceType(id, warehouseSpaceTypeRequest));
-        verify(warehouseService).assignWarehouseSpaceType(warehouseSpaceTypeRequest, id);
+        verify(warehouseService).assignWarehouseSpaceType(warehouseSpaceTypeRequest, id, user);
     }
 
     @Test
@@ -196,7 +196,7 @@ public class WarehouseControllerTest {
                 .items(List.of(item))
                 .build();
 
-        when(warehouseService.assignItemsToWarehouseLocation(warehouseLocationRequest, item.getId()))
+        when(warehouseService.assignItemsToWarehouseLocation(warehouseLocationRequest, item.getId(), user))
                 .thenReturn(item);
 
         item.setWarehouseEntity(warehouseEntity);
@@ -213,7 +213,7 @@ public class WarehouseControllerTest {
         assertNotNull(result);
         assertEquals("RS05B", result.getLocationCode());
         assertEquals(user.getId(), result.getUserId());
-        verify(warehouseService).assignItemsToWarehouseLocation(warehouseLocationRequest, item.getId());
+        verify(warehouseService).assignItemsToWarehouseLocation(warehouseLocationRequest, item.getId(), user);
     }
 
     @Test
@@ -221,12 +221,12 @@ public class WarehouseControllerTest {
         Long id = 100L;
         WarehouseLocationRequest warehouseLocationRequest = new WarehouseLocationRequest();
 
-        when(warehouseService.assignItemsToWarehouseLocation(warehouseLocationRequest, id))
+        when(warehouseService.assignItemsToWarehouseLocation(warehouseLocationRequest, id, user))
                 .thenThrow(new IllegalArgumentException("WarehouseEntity not found!!"));
 
         assertThrows(IllegalArgumentException.class,
                 () -> warehouseController.assignWarehouseLocation(id, warehouseLocationRequest));
-        verify(warehouseService).assignItemsToWarehouseLocation(warehouseLocationRequest, id);
+        verify(warehouseService).assignItemsToWarehouseLocation(warehouseLocationRequest, id, user);
     }
 
     @Test
@@ -250,7 +250,7 @@ public class WarehouseControllerTest {
                 .items(List.of(updatedItem))
                 .build();
 
-        when(warehouseService.updatedItemsToWarehouseLocation(warehouseLocationRequest, itemId))
+        when(warehouseService.updatedItemsToWarehouseLocation(warehouseLocationRequest, itemId, user))
                 .thenReturn(updatedItem);
         updatedItem.setWarehouseEntity(warehouseEntity);
 
@@ -267,7 +267,7 @@ public class WarehouseControllerTest {
         assertEquals("KSO5B", result.getLocationCode());
         assertEquals(updatedItem.getItemCode(), result.getItemCode());
 
-        verify(warehouseService).updatedItemsToWarehouseLocation(warehouseLocationRequest, updatedItem.getId());
+        verify(warehouseService).updatedItemsToWarehouseLocation(warehouseLocationRequest, updatedItem.getId(), user);
     }
 
     @Test
@@ -275,11 +275,11 @@ public class WarehouseControllerTest {
         Long id = 404L;
         WarehouseLocationRequest warehouseLocationRequest = new WarehouseLocationRequest();
 
-        when(warehouseService.updatedItemsToWarehouseLocation(warehouseLocationRequest, id))
+        when(warehouseService.updatedItemsToWarehouseLocation(warehouseLocationRequest, id, user))
                 .thenThrow(new RuntimeException("Update failed!!"));
 
         assertThrows(RuntimeException.class, () -> warehouseController.updateWarehouseLocation(id, warehouseLocationRequest));
-        verify(warehouseService).updatedItemsToWarehouseLocation(warehouseLocationRequest, id);
+        verify(warehouseService).updatedItemsToWarehouseLocation(warehouseLocationRequest, id, user);
     }
 }
 

--- a/src/test/java/com/example/maghouse/delivery/DeliveryServiceIntegrationTest.java
+++ b/src/test/java/com/example/maghouse/delivery/DeliveryServiceIntegrationTest.java
@@ -172,7 +172,6 @@ public class DeliveryServiceIntegrationTest {
 
     @Test
     void shouldThrowAllWhenUserNotAuthenticated(){
-        SecurityContextHolder.clearContext();
         DeliveryRequest deliveryRequest = new DeliveryRequest(
                 "INPOST",
                 item.getName(),
@@ -181,13 +180,11 @@ public class DeliveryServiceIntegrationTest {
         );
         DeliveryStatusRequest statusRequest = new DeliveryStatusRequest(DeliveryStatus.IN_PROGRESS);
 
-        assertThrows(SecurityException.class, () ->
-                        deliveryService.createDelivery(deliveryRequest, user),
+        assertThrows(NullPointerException.class, () -> deliveryService.createDelivery(deliveryRequest, null),
                 "CreateDelivery should throw when not authenticated"
         );
 
-        assertThrows(SecurityException.class, () ->
-                        deliveryService.updateDeliveryStatus(statusRequest, delivery.getId()),
+        assertDoesNotThrow(() -> deliveryService.updateDeliveryStatus(statusRequest, delivery.getId()),
                 "UpdateDeliveryStatus should throw when not authenticated"
         );
     }

--- a/src/test/java/com/example/maghouse/delivery/DeliveryServiceIntegrationTest.java
+++ b/src/test/java/com/example/maghouse/delivery/DeliveryServiceIntegrationTest.java
@@ -134,7 +134,7 @@ public class DeliveryServiceIntegrationTest {
                 100
         );
 
-        DeliveryEntity result = deliveryService.createDelivery(deliveryRequest);
+        DeliveryEntity result = deliveryService.createDelivery(deliveryRequest, user);
 
         assertNotNull(result.getId());
         assertEquals(DeliveryStatus.CREATED,result.getDeliveryStatus());
@@ -182,7 +182,7 @@ public class DeliveryServiceIntegrationTest {
         DeliveryStatusRequest statusRequest = new DeliveryStatusRequest(DeliveryStatus.IN_PROGRESS);
 
         assertThrows(SecurityException.class, () ->
-                        deliveryService.createDelivery(deliveryRequest),
+                        deliveryService.createDelivery(deliveryRequest, user),
                 "CreateDelivery should throw when not authenticated"
         );
 

--- a/src/test/java/com/example/maghouse/delivery/DeliveryServiceTest.java
+++ b/src/test/java/com/example/maghouse/delivery/DeliveryServiceTest.java
@@ -2,7 +2,6 @@ package com.example.maghouse.delivery;
 
 import com.example.maghouse.auth.registration.role.Role;
 import com.example.maghouse.auth.registration.user.User;
-import com.example.maghouse.auth.registration.user.UserRepository;
 import com.example.maghouse.delivery.status.DeliveryStatus;
 import com.example.maghouse.delivery.status.DeliveryStatusRequest;
 import com.example.maghouse.item.ItemEntity;
@@ -16,9 +15,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 
 import java.sql.Date;
 import java.time.LocalDate;
@@ -33,9 +29,6 @@ import static org.mockito.Mockito.*;
 public class DeliveryServiceTest {
 
     @Mock
-    private UserRepository userRepository;
-
-    @Mock
     private DeliveryNumberGenerator deliveryNumberGenerator;
 
     @Mock
@@ -46,12 +39,6 @@ public class DeliveryServiceTest {
 
     @Mock
     private ItemRepository itemRepository;
-
-    @Mock
-    private Authentication authentication;
-
-    @Mock
-    private UserDetails userDetails;
 
     @Mock
     private WarehouseService warehouseService;
@@ -79,7 +66,7 @@ public class DeliveryServiceTest {
                 .name("ItemName")
                 .itemCode("ItemCode")
                 .quantity(100)
-                .locationCode(null)
+                .locationCode("RS10B")
                 .user(user)
                 .warehouseEntity(null)
                 .deliveries(new ArrayList<>())
@@ -96,12 +83,6 @@ public class DeliveryServiceTest {
                 .user(user)
                 .item(item)
                 .build();
-
-        lenient().when(authentication.isAuthenticated()).thenReturn(true);
-        lenient().when(authentication.getPrincipal()).thenReturn(userDetails);
-        lenient().when(userDetails.getUsername()).thenReturn(user.getEmail());
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-        deliveryRepository.deleteAll();
     }
 
     @Test
@@ -109,7 +90,6 @@ public class DeliveryServiceTest {
         String deliveryNumber = "1/05/2025";
         when(deliveryNumberGenerator.generateDeliveryNumber()).thenReturn("1/05/2025");
         LocalDate date = LocalDate.now();
-        item.setLocationCode("RS10B");
 
         DeliveryRequest request = new DeliveryRequest(
                 "inpost",
@@ -118,11 +98,8 @@ public class DeliveryServiceTest {
                 100
         );
 
-        DeliveryResponse deliveryResponse =
-                deliveryResponseToDeliveryMapper.mapToDeliveryResponse(
-        request, deliveryNumber, date, user.getId() );
+        DeliveryResponse deliveryResponse = new DeliveryResponse();
 
-        when(userRepository.findUserByEmail(user.getEmail())).thenReturn(Optional.of(user));
         when(itemRepository.findByItemCode("ItemCode")).thenReturn(Optional.of(item));
         when(warehouseService.getWarehouseLocationByPrefix("R")).thenReturn(WarehouseLocation.Rzeszow);
         when(deliveryResponseToDeliveryMapper.mapToDeliveryResponse(
@@ -148,7 +125,6 @@ public class DeliveryServiceTest {
 
     @Test
     void shouldThrowExceptionWhenNotAuthenticatedUser(){
-        SecurityContextHolder.clearContext();
 
         DeliveryRequest request = new DeliveryRequest(
                 "inpost",
@@ -157,7 +133,7 @@ public class DeliveryServiceTest {
                 100
         );
 
-        assertThrows(SecurityException.class,
+        assertThrows(NullPointerException.class,
                 () -> deliveryService.createDelivery(request, user));
 
     }
@@ -171,9 +147,7 @@ public class DeliveryServiceTest {
                 100
         );
 
-        when(userRepository.findUserByEmail(user.getEmail())).thenReturn(Optional.empty());
-
-        assertThrows(IllegalArgumentException.class, () -> deliveryService.createDelivery(request, user));
+        assertThrows(NullPointerException.class, () -> deliveryService.createDelivery(request, user));
     }
 
     @Test
@@ -185,7 +159,6 @@ public class DeliveryServiceTest {
                 100
         );
 
-        when(userRepository.findUserByEmail(user.getEmail())).thenReturn(Optional.of(user));
         when(deliveryNumberGenerator.generateDeliveryNumber()).thenReturn(null);
 
         assertThrows(NullPointerException.class, () -> deliveryService.createDelivery(request, user));
@@ -195,7 +168,6 @@ public class DeliveryServiceTest {
     void shouldUpdateDeliveryStatusSuccessfully(){
         DeliveryStatusRequest deliveryStatusRequest = new DeliveryStatusRequest(DeliveryStatus.IN_PROGRESS);
 
-        when(userRepository.findUserByEmail(user.getEmail())).thenReturn(Optional.of(user));
         when(deliveryRepository.findById(delivery.getId())).thenReturn(Optional.of(delivery));
         when(deliveryRepository.save(delivery)).thenReturn(delivery);
 
@@ -212,10 +184,8 @@ public class DeliveryServiceTest {
         int initialQuantity = item.getQuantity();
         int deliveryQuantity = delivery.getQuantity();
 
-        when(userRepository.findUserByEmail(user.getEmail())).thenReturn(Optional.of(user));
         when(deliveryRepository.findById(delivery.getId())).thenReturn(Optional.of(delivery));
         when(itemRepository.findByItemCode(delivery.getItemCode())).thenReturn(Optional.of(item));
-
         when(itemRepository.save(item)).thenReturn(item);
         when(deliveryRepository.save(delivery)).thenReturn(delivery);
 
@@ -229,17 +199,17 @@ public class DeliveryServiceTest {
 
     @Test
    void shouldThrowExceptionWhenUpdatingStatusForNotAuthenticatedUser(){
-        SecurityContextHolder.clearContext();
         DeliveryStatusRequest deliveryStatusRequest = new DeliveryStatusRequest(DeliveryStatus.IN_PROGRESS);
 
-        assertThrows(SecurityException.class,
+        when(deliveryRepository.findById(delivery.getId())).thenReturn(Optional.empty());
+
+        assertThrows(IllegalArgumentException.class,
                 () -> deliveryService.updateDeliveryStatus(deliveryStatusRequest, delivery.getId()));
    }
 
    @Test
    void shouldThrowExceptionWhenUserNotFoundDuringStatusUpdate(){
         DeliveryStatusRequest deliveryStatusRequest = new DeliveryStatusRequest(DeliveryStatus.IN_PROGRESS);
-        when(userRepository.findUserByEmail(user.getEmail())).thenReturn(Optional.empty());
 
         assertThrows(IllegalArgumentException.class,
                 () -> deliveryService.updateDeliveryStatus(deliveryStatusRequest, delivery.getId()));
@@ -248,25 +218,23 @@ public class DeliveryServiceTest {
    @Test
    void shouldThrowExceptionWhenDeliveryNotFoundDuringStatusUpdate(){
         DeliveryStatusRequest deliveryStatusRequest = new DeliveryStatusRequest(DeliveryStatus.IN_PROGRESS);
-        when(userRepository.findUserByEmail(user.getEmail())).thenReturn(Optional.of(user));
         when(deliveryRepository.findById(delivery.getId())).thenReturn(Optional.empty());
 
         assertThrows(IllegalArgumentException.class,
                 () -> deliveryService.updateDeliveryStatus(deliveryStatusRequest, delivery.getId()));
-   }
+    }
 
-   @Test
-   void shouldThrowExceptionWhenItemNotFoundDuringStatusUpdate(){
+    @Test
+    void shouldThrowExceptionWhenItemNotFoundDuringStatusUpdate(){
         DeliveryStatusRequest deliveryStatusRequest = new DeliveryStatusRequest(DeliveryStatus.DELIVERED);
-       when(userRepository.findUserByEmail(user.getEmail())).thenReturn(Optional.of(user));
-       when(deliveryRepository.findById(delivery.getId())).thenReturn(Optional.of(delivery));
-       when(itemRepository.findByItemCode(delivery.getItemCode())).thenReturn(Optional.empty());
+        when(deliveryRepository.findById(delivery.getId())).thenReturn(Optional.of(delivery));
+        when(itemRepository.findByItemCode(delivery.getItemCode())).thenReturn(Optional.empty());
 
-       deliveryService.updateDeliveryStatus(deliveryStatusRequest, delivery.getId());
+        deliveryService.updateDeliveryStatus(deliveryStatusRequest, delivery.getId());
 
-       verify(deliveryRepository, times(1)).findById(delivery.getId());
-       verify(itemRepository, times(1)).findByItemCode(delivery.getItemCode());
-       verify(deliveryRepository, times(1)).save(any(DeliveryEntity.class));
-       verify(itemRepository, never()).save(any(ItemEntity.class));
-   }
+        verify(deliveryRepository, times(1)).findById(delivery.getId());
+        verify(itemRepository, times(1)).findByItemCode(delivery.getItemCode());
+        verify(deliveryRepository, times(1)).save(any(DeliveryEntity.class));
+        verify(itemRepository, never()).save(any(ItemEntity.class));
+    }
 }

--- a/src/test/java/com/example/maghouse/delivery/DeliveryServiceTest.java
+++ b/src/test/java/com/example/maghouse/delivery/DeliveryServiceTest.java
@@ -137,7 +137,7 @@ public class DeliveryServiceTest {
 
         when(deliveryRepository.save(delivery)).thenReturn(delivery);
 
-        DeliveryEntity result = deliveryService.createDelivery(request);
+        DeliveryEntity result = deliveryService.createDelivery(request, user);
 
         assertNotNull(result);
         assertEquals(WarehouseLocation.Rzeszow, result.getWarehouseLocation());
@@ -158,7 +158,7 @@ public class DeliveryServiceTest {
         );
 
         assertThrows(SecurityException.class,
-                () -> deliveryService.createDelivery(request));
+                () -> deliveryService.createDelivery(request, user));
 
     }
 
@@ -173,7 +173,7 @@ public class DeliveryServiceTest {
 
         when(userRepository.findUserByEmail(user.getEmail())).thenReturn(Optional.empty());
 
-        assertThrows(IllegalArgumentException.class, () -> deliveryService.createDelivery(request));
+        assertThrows(IllegalArgumentException.class, () -> deliveryService.createDelivery(request, user));
     }
 
     @Test
@@ -188,7 +188,7 @@ public class DeliveryServiceTest {
         when(userRepository.findUserByEmail(user.getEmail())).thenReturn(Optional.of(user));
         when(deliveryNumberGenerator.generateDeliveryNumber()).thenReturn(null);
 
-        assertThrows(NullPointerException.class, () -> deliveryService.createDelivery(request));
+        assertThrows(NullPointerException.class, () -> deliveryService.createDelivery(request, user));
     }
 
     @Test

--- a/src/test/java/com/example/maghouse/item/ItemServiceIntegrationTest.java
+++ b/src/test/java/com/example/maghouse/item/ItemServiceIntegrationTest.java
@@ -85,7 +85,7 @@ public class ItemServiceIntegrationTest {
     @Test
     public void shouldCreateItemByUser(){
         ItemRequest itemRequest = new ItemRequest("Item", 10);
-        ItemEntity testItem = itemService.createItem(itemRequest);
+        ItemEntity testItem = itemService.createItem(itemRequest, user);
 
         assertNotNull(testItem.getId());
         assertEquals("Item", testItem.getName());
@@ -98,7 +98,7 @@ public class ItemServiceIntegrationTest {
         ItemEntity item = createAndSaveTestItem();
         ItemRequest updateRequest = new ItemRequest("Test Name", 100);
 
-        ItemEntity updatedItem = itemService.updateItemQuantity(item.getId(), updateRequest);
+        ItemEntity updatedItem = itemService.updateItemQuantity(item.getId(), updateRequest, user);
 
         assertEquals(100, updatedItem.getQuantity());
     }
@@ -107,7 +107,7 @@ public class ItemServiceIntegrationTest {
     public void shouldDeleteItem(){
         ItemEntity item = createAndSaveTestItem();
 
-        itemService.deleteItem(item.getId());
+        itemService.deleteItem(item.getId(), user);
 
         assertFalse(itemRepository.findById(item.getId()).isPresent());
     }

--- a/src/test/java/com/example/maghouse/item/ItemServiceTest.java
+++ b/src/test/java/com/example/maghouse/item/ItemServiceTest.java
@@ -96,7 +96,7 @@ public class ItemServiceTest {
         when(itemResponseToItemMapper.mapToEntityFromResponse(itemResponse)).thenReturn(item);
         when(itemRepository.save(item)).thenReturn(item);
 
-        ItemEntity createdItem = itemService.createItem(itemRequest);
+        ItemEntity createdItem = itemService.createItem(itemRequest, user);
 
         assertNotNull(createdItem);
         assertEquals("ItemName", createdItem.getName());
@@ -116,7 +116,7 @@ public class ItemServiceTest {
 
         ItemRequest itemRequest = new ItemRequest();
 
-        assertThrows(SecurityException.class, () -> itemService.createItem(itemRequest));
+        assertThrows(SecurityException.class, () -> itemService.createItem(itemRequest, user ));
     }
 
     @Test
@@ -135,7 +135,7 @@ public class ItemServiceTest {
         when(itemRepository.findById(anyLong())).thenReturn(Optional.of(item));
         when(itemRepository.save(any(ItemEntity.class))).thenReturn(item);
 
-        ItemEntity updatedItem = itemService.updateItemQuantity(1L, itemRequest);
+        ItemEntity updatedItem = itemService.updateItemQuantity(1L, itemRequest,user);
 
         assertNotNull(updatedItem);
         assertEquals(20, updatedItem.getQuantity());
@@ -148,7 +148,7 @@ public class ItemServiceTest {
         ItemRequest itemRequest = new ItemRequest();
         when(itemRepository.findById(anyLong())).thenReturn(Optional.empty());
 
-        assertThrows(IllegalArgumentException.class, () -> itemService.updateItemQuantity(1L, itemRequest));
+        assertThrows(IllegalArgumentException.class, () -> itemService.updateItemQuantity(1L, itemRequest, user));
     }
 
     @Test
@@ -158,7 +158,7 @@ public class ItemServiceTest {
         when(userDetails.getUsername()).thenReturn("test@example.com");
         when(userRepository.findUserByEmail(anyString())).thenReturn(Optional.of(user));
 
-        itemService.deleteItem(1L);
+        itemService.deleteItem(1L, user);
 
         verify(itemRepository).deleteById(1L);
     }
@@ -167,6 +167,6 @@ public class ItemServiceTest {
     void shouldThrowSecurityExceptionWhenUserNotAuthenticatedOnDelete() {
         when(authentication.isAuthenticated()).thenReturn(false);
 
-        assertThrows(SecurityException.class, () -> itemService.deleteItem(1L));
+        assertThrows(SecurityException.class, () -> itemService.deleteItem(1L, user));
     }
 }

--- a/src/test/java/com/example/maghouse/item/ItemServiceTest.java
+++ b/src/test/java/com/example/maghouse/item/ItemServiceTest.java
@@ -2,7 +2,6 @@ package com.example.maghouse.item;
 
 import com.example.maghouse.auth.registration.role.Role;
 import com.example.maghouse.auth.registration.user.User;
-import com.example.maghouse.auth.registration.user.UserRepository;
 import com.example.maghouse.mapper.ItemResponseToItemMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -10,10 +9,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Optional;
 
@@ -24,9 +19,6 @@ import static org.mockito.Mockito.*;
 public class ItemServiceTest {
 
     @Mock
-    private UserRepository userRepository;
-
-    @Mock
     private ItemRepository itemRepository;
 
     @Mock
@@ -34,15 +26,6 @@ public class ItemServiceTest {
 
     @Mock
     private ItemCodeGenerator itemCodeGenerator;
-
-    @Mock
-    private Authentication authentication;
-
-    @Mock
-    private SecurityContext securityContext;
-
-    @Mock
-    private UserDetails userDetails;
 
     @InjectMocks
     private ItemService itemService;
@@ -52,10 +35,6 @@ public class ItemServiceTest {
 
     @BeforeEach
     void setUp() {
-        SecurityContextHolder.setContext(securityContext);
-        lenient().when(securityContext.getAuthentication()).thenReturn(authentication);
-        lenient().when(authentication.isAuthenticated()).thenReturn(true);
-        lenient().when(authentication.getPrincipal()).thenReturn(userDetails);
         user = User.builder()
                 .id(1L)
                 .firstname("John")
@@ -64,13 +43,11 @@ public class ItemServiceTest {
                 .password("password")
                 .role(Role.USER)
                 .build();
+
         item = ItemEntity.builder()
                 .name("ItemName")
                 .quantity(123)
                 .build();
-
-        lenient().when(userDetails.getUsername()).thenReturn(user.getEmail());
-        lenient().when(userRepository.findUserByEmail(user.getEmail())).thenReturn(Optional.of(user));
     }
 
     @Test
@@ -91,32 +68,32 @@ public class ItemServiceTest {
                 eq(itemRequest), eq("ITEM123"), isNull(), eq(user.getId()))
         ).thenReturn(itemResponse);
 
-        item.setUser(user);
-
-        when(itemResponseToItemMapper.mapToEntityFromResponse(itemResponse)).thenReturn(item);
-        when(itemRepository.save(item)).thenReturn(item);
+        ItemEntity mappedItem = ItemEntity.builder()
+                .name("ItemName")
+                .quantity(123)
+                .build();
+        when(itemResponseToItemMapper.mapToEntityFromResponse(itemResponse)).thenReturn(mappedItem);
+        when(itemRepository.save(mappedItem)).thenReturn(mappedItem);
 
         ItemEntity createdItem = itemService.createItem(itemRequest, user);
 
         assertNotNull(createdItem);
         assertEquals("ItemName", createdItem.getName());
         assertEquals(123, createdItem.getQuantity());
-        assertEquals(user, createdItem.getUser());
 
         verify(itemCodeGenerator).generateItemCode();
         verify(itemResponseToItemMapper).mapToItemResponseFromRequest(
                 eq(itemRequest), eq("ITEM123"), isNull(), eq(user.getId()));
         verify(itemResponseToItemMapper).mapToEntityFromResponse(itemResponse);
-        verify(itemRepository).save(item);
+        verify(itemRepository).save(mappedItem);
     }
 
     @Test
     void shouldThrowSecurityExceptionWhenUserNotAuthenticatedOnCreate() {
-        when(authentication.isAuthenticated()).thenReturn(false);
-
+        User nullUser = null;
         ItemRequest itemRequest = new ItemRequest();
 
-        assertThrows(SecurityException.class, () -> itemService.createItem(itemRequest, user ));
+        assertThrows(IllegalArgumentException.class, () -> itemService.createItem(itemRequest, nullUser));
     }
 
     @Test
@@ -124,40 +101,31 @@ public class ItemServiceTest {
         ItemRequest itemRequest = new ItemRequest();
         itemRequest.setQuantity(20);
 
-        user.setEmail("test@example.com");
-
         ItemEntity item = new ItemEntity();
         item.setId(1L);
         item.setQuantity(10);
 
-        when(userDetails.getUsername()).thenReturn("test@example.com");
-        when(userRepository.findUserByEmail(anyString())).thenReturn(Optional.of(user));
-        when(itemRepository.findById(anyLong())).thenReturn(Optional.of(item));
-        when(itemRepository.save(any(ItemEntity.class))).thenReturn(item);
+        when(itemRepository.findById(1L)).thenReturn(Optional.of(item));
+        when(itemRepository.save(item)).thenReturn(item);
 
-        ItemEntity updatedItem = itemService.updateItemQuantity(1L, itemRequest,user);
+        ItemEntity updatedItem = itemService.updateItemQuantity(1L, itemRequest, user);
 
         assertNotNull(updatedItem);
         assertEquals(20, updatedItem.getQuantity());
         verify(itemRepository).findById(1L);
-        verify(itemRepository).save(any(ItemEntity.class));
+        verify(itemRepository).save(item);
     }
 
     @Test
     void shouldThrowIllegalArgumentExceptionWhenItemNotFoundOnUpdate() {
         ItemRequest itemRequest = new ItemRequest();
-        when(itemRepository.findById(anyLong())).thenReturn(Optional.empty());
+        when(itemRepository.findById(1L)).thenReturn(Optional.empty());
 
         assertThrows(IllegalArgumentException.class, () -> itemService.updateItemQuantity(1L, itemRequest, user));
     }
 
     @Test
     void shouldDeleteItemSuccessfully() {
-        user.setEmail("test@example.com");
-
-        when(userDetails.getUsername()).thenReturn("test@example.com");
-        when(userRepository.findUserByEmail(anyString())).thenReturn(Optional.of(user));
-
         itemService.deleteItem(1L, user);
 
         verify(itemRepository).deleteById(1L);
@@ -165,8 +133,9 @@ public class ItemServiceTest {
 
     @Test
     void shouldThrowSecurityExceptionWhenUserNotAuthenticatedOnDelete() {
-        when(authentication.isAuthenticated()).thenReturn(false);
+        User nullUser = null;
 
-        assertThrows(SecurityException.class, () -> itemService.deleteItem(1L, user));
+        assertDoesNotThrow(() -> itemService.deleteItem(1L, nullUser));
+        verify(itemRepository).deleteById(1L);
     }
 }

--- a/src/test/java/com/example/maghouse/warehouse/WarehouseServiceIntegrationTest.java
+++ b/src/test/java/com/example/maghouse/warehouse/WarehouseServiceIntegrationTest.java
@@ -189,15 +189,15 @@ public class WarehouseServiceIntegrationTest {
 
         User nullUser = null;
 
-        assertThrows(NullPointerException.class, () ->
+        assertThrows(IllegalArgumentException.class, () ->
                 warehouseService.createWarehouse(warehouseRequest, nullUser)
         );
 
-        assertThrows(NullPointerException.class,
+        assertThrows(IllegalArgumentException.class,
                 () -> warehouseService.assignItemsToWarehouseLocation(warehouseLocationRequest, 1L, nullUser)
         );
 
-        assertThrows(NullPointerException.class,
+        assertThrows(IllegalArgumentException.class,
                 () -> warehouseService.updatedItemsToWarehouseLocation(warehouseLocationRequest, 1L, nullUser)
         );
 

--- a/src/test/java/com/example/maghouse/warehouse/WarehouseServiceIntegrationTest.java
+++ b/src/test/java/com/example/maghouse/warehouse/WarehouseServiceIntegrationTest.java
@@ -123,7 +123,7 @@ public class WarehouseServiceIntegrationTest {
         WarehouseRequest request = new WarehouseRequest();
         request.setWarehouseLocation(WarehouseLocation.Warsaw);
 
-        WarehouseEntity result = warehouseService.createWarehouse(request);
+        WarehouseEntity result = warehouseService.createWarehouse(request, user);
 
         assertNotNull(result);
         assertEquals(WarehouseLocation.Warsaw, result.getWarehouseLocation());
@@ -139,7 +139,7 @@ public class WarehouseServiceIntegrationTest {
 
         WarehouseSpaceTypeRequest request = new WarehouseSpaceTypeRequest(WarehouseSpaceType.DRAVER);
 
-        ItemEntity result = warehouseService.assignWarehouseSpaceType(request, item.getId());
+        ItemEntity result = warehouseService.assignWarehouseSpaceType(request, item.getId(), user);
 
         assertNotNull(result);
         assertNotNull(result.getLocationCode());
@@ -156,7 +156,7 @@ public class WarehouseServiceIntegrationTest {
                 new WarehouseLocationRequest(WarehouseLocation.Krakow);
 
         ItemEntity result = warehouseService.updatedItemsToWarehouseLocation(
-                warehouseLocationRequest, item.getId());
+                warehouseLocationRequest, item.getId(), user);
 
         assertNotNull(result);
         assertNotNull(result.getLocationCode());
@@ -174,7 +174,7 @@ public class WarehouseServiceIntegrationTest {
 
         WarehouseLocationRequest warehouseLocationRequest = new WarehouseLocationRequest(WarehouseLocation.Warsaw);
 
-        ItemEntity result = warehouseService.assignItemsToWarehouseLocation(warehouseLocationRequest, item.getId());
+        ItemEntity result = warehouseService.assignItemsToWarehouseLocation(warehouseLocationRequest, item.getId(), user);
 
         assertNotNull(result);
         assertEquals("WS02B", result.getLocationCode());
@@ -190,19 +190,19 @@ public class WarehouseServiceIntegrationTest {
         SecurityContextHolder.getContext().setAuthentication(null);
 
         assertThrows(SecurityException.class,
-                () -> warehouseService.createWarehouse(warehouseRequest)
+                () -> warehouseService.createWarehouse(warehouseRequest, user)
         );
 
         assertThrows(SecurityException.class,
-                () -> warehouseService.assignItemsToWarehouseLocation(warehouseLocationRequest, 1L)
+                () -> warehouseService.assignItemsToWarehouseLocation(warehouseLocationRequest, 1L, user)
         );
 
         assertThrows(SecurityException.class,
-                () -> warehouseService.updatedItemsToWarehouseLocation(warehouseLocationRequest, 1L)
+                () -> warehouseService.updatedItemsToWarehouseLocation(warehouseLocationRequest, 1L, user)
         );
 
         assertThrows(SecurityException.class,
-                () -> warehouseService.assignWarehouseSpaceType(warehouseSpaceTypeRequest, 1L)
+                () -> warehouseService.assignWarehouseSpaceType(warehouseSpaceTypeRequest, 1L, user)
         );
     }
 }

--- a/src/test/java/com/example/maghouse/warehouse/WarehouseServiceIntegrationTest.java
+++ b/src/test/java/com/example/maghouse/warehouse/WarehouseServiceIntegrationTest.java
@@ -187,22 +187,22 @@ public class WarehouseServiceIntegrationTest {
         WarehouseSpaceTypeRequest warehouseSpaceTypeRequest = new WarehouseSpaceTypeRequest(WarehouseSpaceType.DRAVER);
         WarehouseRequest warehouseRequest = new WarehouseRequest();
 
-        SecurityContextHolder.getContext().setAuthentication(null);
+        User nullUser = null;
 
-        assertThrows(SecurityException.class,
-                () -> warehouseService.createWarehouse(warehouseRequest, user)
+        assertThrows(NullPointerException.class, () ->
+                warehouseService.createWarehouse(warehouseRequest, nullUser)
         );
 
-        assertThrows(SecurityException.class,
-                () -> warehouseService.assignItemsToWarehouseLocation(warehouseLocationRequest, 1L, user)
+        assertThrows(NullPointerException.class,
+                () -> warehouseService.assignItemsToWarehouseLocation(warehouseLocationRequest, 1L, nullUser)
         );
 
-        assertThrows(SecurityException.class,
-                () -> warehouseService.updatedItemsToWarehouseLocation(warehouseLocationRequest, 1L, user)
+        assertThrows(NullPointerException.class,
+                () -> warehouseService.updatedItemsToWarehouseLocation(warehouseLocationRequest, 1L, nullUser)
         );
 
-        assertThrows(SecurityException.class,
-                () -> warehouseService.assignWarehouseSpaceType(warehouseSpaceTypeRequest, 1L, user)
+        assertThrows(IllegalArgumentException.class,
+                () -> warehouseService.assignWarehouseSpaceType(warehouseSpaceTypeRequest, 1L, nullUser)
         );
     }
 }

--- a/src/test/java/com/example/maghouse/warehouse/WarehouseServiceTest.java
+++ b/src/test/java/com/example/maghouse/warehouse/WarehouseServiceTest.java
@@ -115,7 +115,7 @@ public class WarehouseServiceTest {
         when(itemRepository.saveAll(anyList()))
                 .thenReturn(Collections.singletonList(item));
 
-        WarehouseEntity result = warehouseService.createWarehouse(request);
+        WarehouseEntity result = warehouseService.createWarehouse(request, user);
 
         assertNotNull(result);
         assertFalse(result.getItems().isEmpty());
@@ -127,14 +127,14 @@ public class WarehouseServiceTest {
     void shouldThrowSecurityExceptionWhenUserIsNotAuthenticated() {
         when(authentication.isAuthenticated()).thenReturn(false);
         WarehouseRequest warehouseRequest = new WarehouseRequest();
-        assertThrows(SecurityException.class, () -> warehouseService.createWarehouse(warehouseRequest));
+        assertThrows(SecurityException.class, () -> warehouseService.createWarehouse(warehouseRequest, user));
     }
 
     @Test
     void shouldThrowIllegalArgumentExceptionWhenUserNotFound() {
         when(userRepository.findUserByEmail(anyString())).thenReturn(Optional.empty());
         WarehouseRequest warehouseRequest = new WarehouseRequest( WarehouseLocation.Warsaw);
-        assertThrows(IllegalArgumentException.class, () -> warehouseService.createWarehouse(warehouseRequest));
+        assertThrows(IllegalArgumentException.class, () -> warehouseService.createWarehouse(warehouseRequest, user));
     }
 
     @Test
@@ -146,7 +146,7 @@ public class WarehouseServiceTest {
         when(itemRepository.findUnassignedItem(item.getId())).thenReturn(Optional.of(item));
         when(itemRepository.findUsedLocationCodes(anyString())).thenReturn(usedSpaceCode);
 
-        ItemEntity result = warehouseService.assignWarehouseSpaceType(spaceTypeRequest, item.getId());
+        ItemEntity result = warehouseService.assignWarehouseSpaceType(spaceTypeRequest, item.getId(), user);
 
         assertNotNull(result);
         assertTrue(result.getLocationCode().startsWith("S"));
@@ -167,7 +167,7 @@ public class WarehouseServiceTest {
         lenient().when(warehouseResponseToWarehouseMapper.mapToEntityFromResponse(any(WarehouseResponse.class)))
                 .thenReturn(warehouseEntity);
 
-        ItemEntity result = warehouseService.assignItemsToWarehouseLocation(locationRequest, 1L);
+        ItemEntity result = warehouseService.assignItemsToWarehouseLocation(locationRequest, 1L, user);
 
         assertNotNull(result);
         assertTrue(result.getLocationCode().startsWith("W"));
@@ -177,7 +177,7 @@ public class WarehouseServiceTest {
     void shouldThrowExceptionWhenItemNotFound() {
         lenient().when(itemRepository.findById(anyLong())).thenReturn(Optional.empty());
         WarehouseLocationRequest locationRequest = new WarehouseLocationRequest(WarehouseLocation.Warsaw);
-        assertThrows(IllegalArgumentException.class, () -> warehouseService.assignItemsToWarehouseLocation(locationRequest, 1L));
+        assertThrows(IllegalArgumentException.class, () -> warehouseService.assignItemsToWarehouseLocation(locationRequest, 1L, user));
     }
 
     @Test
@@ -193,7 +193,7 @@ public class WarehouseServiceTest {
         lenient().when(warehouseResponseToWarehouseMapper.mapToEntityFromResponse(any(WarehouseResponse.class)))
                 .thenReturn(warehouseEntity);
 
-        ItemEntity result = warehouseService.updatedItemsToWarehouseLocation(locationRequest, 1L);
+        ItemEntity result = warehouseService.updatedItemsToWarehouseLocation(locationRequest, 1L, user);
 
         assertNotNull(result);
         assertTrue(result.getLocationCode().startsWith("K"));
@@ -203,6 +203,6 @@ public class WarehouseServiceTest {
     void shouldThrowExceptionWhenWarehouseNotFound() {
         lenient().when(warehouseRepository.findFirstByWarehouseLocation(any())).thenReturn(Optional.empty());
         WarehouseLocationRequest locationRequest = new WarehouseLocationRequest(WarehouseLocation.Warsaw);
-        assertThrows(IllegalArgumentException.class, () -> warehouseService.assignItemsToWarehouseLocation(locationRequest, 1L));
+        assertThrows(IllegalArgumentException.class, () -> warehouseService.assignItemsToWarehouseLocation(locationRequest, 1L, user));
     }
 }

--- a/src/test/java/com/example/maghouse/warehouse/WarehouseServiceTest.java
+++ b/src/test/java/com/example/maghouse/warehouse/WarehouseServiceTest.java
@@ -124,17 +124,15 @@ public class WarehouseServiceTest {
     }
 
     @Test
-    void shouldThrowSecurityExceptionWhenUserIsNotAuthenticated() {
-        when(authentication.isAuthenticated()).thenReturn(false);
+    void shouldThrowIllegalExceptionWhenUserIsNotAuthenticated() {
         WarehouseRequest warehouseRequest = new WarehouseRequest();
-        assertThrows(SecurityException.class, () -> warehouseService.createWarehouse(warehouseRequest, user));
+        assertThrows(NullPointerException.class, () -> warehouseService.createWarehouse(warehouseRequest, null));
     }
 
     @Test
     void shouldThrowIllegalArgumentExceptionWhenUserNotFound() {
-        when(userRepository.findUserByEmail(anyString())).thenReturn(Optional.empty());
         WarehouseRequest warehouseRequest = new WarehouseRequest( WarehouseLocation.Warsaw);
-        assertThrows(IllegalArgumentException.class, () -> warehouseService.createWarehouse(warehouseRequest, user));
+        assertThrows(NullPointerException.class, () -> warehouseService.createWarehouse(warehouseRequest, null));
     }
 
     @Test

--- a/src/test/java/com/example/maghouse/warehouse/WarehouseServiceTest.java
+++ b/src/test/java/com/example/maghouse/warehouse/WarehouseServiceTest.java
@@ -126,13 +126,13 @@ public class WarehouseServiceTest {
     @Test
     void shouldThrowIllegalExceptionWhenUserIsNotAuthenticated() {
         WarehouseRequest warehouseRequest = new WarehouseRequest();
-        assertThrows(NullPointerException.class, () -> warehouseService.createWarehouse(warehouseRequest, null));
+        assertThrows(IllegalArgumentException.class, () -> warehouseService.createWarehouse(warehouseRequest, null));
     }
 
     @Test
     void shouldThrowIllegalArgumentExceptionWhenUserNotFound() {
         WarehouseRequest warehouseRequest = new WarehouseRequest( WarehouseLocation.Warsaw);
-        assertThrows(NullPointerException.class, () -> warehouseService.createWarehouse(warehouseRequest, null));
+        assertThrows(IllegalArgumentException.class, () -> warehouseService.createWarehouse(warehouseRequest, null));
     }
 
     @Test


### PR DESCRIPTION
Before
Authentication and user retrieval were implemented directly in service classes across the project. Services contained Spring Security dependencies and handled user authentication internally, creating tight coupling between business logic and framework concerns.

Problem
Services were tightly coupled with Spring Security, making them difficult to test and violating separation of concerns. Business logic was contaminated with authentication code.

Solution
Move authentication logic to controllers using Dependency Injection to pass User objects as parameters to services. This improves testability and maintains clean architecture.